### PR TITLE
fix: actually fix title id spelling

### DIFF
--- a/cartridges/app_imgix_base_sfra/cartridge/experience/components/imgix/testcomp.js
+++ b/cartridges/app_imgix_base_sfra/cartridge/experience/components/imgix/testcomp.js
@@ -10,7 +10,7 @@ module.exports.render = function (context, modelIn) {
   var model = modelIn || new HashMap();
   var content = context.content;
 
-  model.title = content.title ? content.tittle : null;
+  model.title = content.title ? content.title : null;
   model.image = ImageTransformation.getScaledImage(content.image);
   // use to give link on the image, if we click on image it take to us to that page.
   model.link = content.imageLink ? content.imageLink : "#";

--- a/cartridges/app_imgix_base_sfra/cartridge/experience/components/imgix/testcomp.json
+++ b/cartridges/app_imgix_base_sfra/cartridge/experience/components/imgix/testcomp.json
@@ -1,7 +1,7 @@
 {
   "name": "Image & Tittle",
   "description": "Image & Tittle",
-  "group": "imgix", 
+  "group": "imgix",
   "attribute_definition_groups": [
     {
       "id": "ImgixImage",
@@ -20,8 +20,8 @@
           "required": false
         },
         {
-          "id": "Tittle",
-          "name": "Tittle",
+          "id": "title",
+          "name": "Title",
           "type": "markup",
           "required": false
         },


### PR DESCRIPTION
The priovus commit tried to address this issue by committing the
incorrect spelling. It turns out the issue stemmed from the ID being
uppercased in the json, not the incorrect spelling.

Both the issue with the uppercased ID and the spelling of `ttitle` are
addressed in this commit.