### PR TITLE
config(circle-ci): build project on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
           app-dir: frontend
           pkg-manager: yarn
       - run:
+          command: cd frontend && yarn run build
+          name: Build project
+      - run:
           command: cd frontend && yarn run test:ci
           name: Run integration and BM cartridge tests with CI flag
 


### PR DESCRIPTION

This PR configures the CI build to build the frontend project. Currently, only the tests are built on CI, which doesn't do type checking or actually build the project. This would help fix that. 

An open question here is: is this the right command to run? Do we maybe want to run a different command, or maybe are we just not ready for this yet.