### PR TITLE
[PE-1331-1] chore: change asset type to match api response - DRAFT

### DIFF
--- a/frontend/src/types/asset.ts
+++ b/frontend/src/types/asset.ts
@@ -1,4 +1,7 @@
 export type Asset = {
-  filename: string;
-  url: string;
+  attributes: {
+    origin_path: string;
+    source_id: string;
+  };
+  id: string;
 };


### PR DESCRIPTION
This commit changes the `Asset` type to more closely match the imgix API response object. The response does not have a `filename` value but it does have a `attributes` and `attributes.origin_path` attribute for instance.



<!---GHSTACKOPEN-->
### Stacked PR Chain: PE-1331-1
| PR | Title |  Merges Into  |
|:--:|:------|:-------------:|
|#27|[PE-1331-1] style: ensure dropdown doesn't cause layout shift - DRAFT|**N/A**|
|#28|[PE-1331-1] chore: shorten placeholder text for search - DRAFT|#27|
|#31|[PE-1331-1] style: set source select z index above search - DRAFT|#28|
|#32|[PE-1331-1] feat: add handleSelect callback to SourceSelect component - DRAFT|#31|
|#33|[PE-1331-1] refactor: use reactimgix to render assets - DRAFT|#32|
|#34|[PE-1331-1] feat: create asset browser component - DRAFT|#33|
|#40|[PE-1331-1] chore: remove duplicate types|#34|
|#41|[PE-1331-1] chore: use imgix api type in components|#40|
|#29|~~[PE-1331-1] chore: add custom domains to source type - DRAFT~~|**Merged**|
|#30|~~[PE-1331-1] chore: change asset type to match api response - DRAFT~~|**Merged**|

<!---GHSTACKCLOSE-->



