### PR TITLE
[PE-1502] chore: build in SF scripts into frontend build

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,17 +1,38 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import "./styles/index.css";
 import { App } from "./components/";
-import reportWebVitals from "./reportWebVitals";
+import "./styles/index.css";
 
-ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-  document.getElementById("root")
-);
+declare const listen: Function;
+
+var rootEditorElement;
+/**
+ * Initializes the base markup before page is ready. This is not part of the API, and called explicitly at the end of this module.
+ */
+function init() {
+  rootEditorElement = document.createElement("div");
+  rootEditorElement.innerHTML = `<h3>Should be replaced by React</h3>`;
+  document.body.appendChild(rootEditorElement);
+  ReactDOM.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+    rootEditorElement
+  );
+}
+
+listen("sfcc:ready", () => {
+  init();
+});
+
+// When a value was selected
+listen("sfcc:value", (value: any) => {});
+// When the editor must require the user to select something
+listen("sfcc:required", (value: any) => {});
+// When the editor is asked to disable its controls
+listen("sfcc:disabled", (value: any) => {});
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+// reportWebVitals();


### PR DESCRIPTION
This PR replaces the index script of the CRA app with SF-related code. Some work will probably need to be done to make this "polymorphic" for both apps. I'm not too worried about this though - for now, we can just hard-code this for the sidebar app. This PR is the only PR in this stack ready to merge 😅 

<!---GHSTACKOPEN-->
### Stacked PR Chain: PE-1502
| PR | Title |  Merges Into  |
|:--:|:------|:-------------:|
|#42|[PE-1502] chore: add temporary image placeholder - DRAFT|**N/A**|
|#44|[PE-1502] chore: disable create react app chunking - DRAFT|#42|
|#45|[PE-1502] chore: update sidebar app to not break build and load image from imgix|#44|
|#46|[PE-1502] chore: build in SF scripts into frontend build|#45|
|#47|[PE-1502] chore: check in example built working app|#46|

<!---GHSTACKCLOSE-->

