### PR TITLE
[PE-1322] feat: create metadata import files

### DIFF
--- a/metadata/imgix_data/meta/system-objecttype-extensions.xml
+++ b/metadata/imgix_data/meta/system-objecttype-extensions.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://www.demandware.com/xml/impex/metadata/2006-10-31">
+    <type-extension type-id="SitePreferences">
+        <custom-attribute-definitions>
+            <attribute-definition attribute-id="imgixPageDesignerAPIkey">
+                <display-name xml:lang="x-default">imgix API Key</display-name>
+                <description xml:lang="x-default">The API Key of your imgix account</description>
+                <type>string</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <min-length>0</min-length>
+            </attribute-definition>
+            <attribute-definition attribute-id="imgixPageDesignerSourceName">
+                <display-name xml:lang="x-default">imgix Origin Name</display-name>
+                <description xml:lang="x-default">The Origin Name of your imgix account</description>
+                <type>string</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <min-length>0</min-length>
+            </attribute-definition>
+        </custom-attribute-definitions>
+        <group-definitions>
+            <attribute-group group-id="imgixPageDesigner">
+                <display-name xml:lang="x-default">imgix Page Designer</display-name>
+                <attribute attribute-id="imgixPageDesignerSourceName"/>
+                <attribute attribute-id="imgixPageDesignerAPIkey"/>
+            </attribute-group>
+        </group-definitions>
+    </type-extension>
+</metadata>

--- a/metadata/imgix_data/services.xml
+++ b/metadata/imgix_data/services.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<services xmlns="http://www.demandware.com/xml/impex/services/2014-09-26">
+    <service service-id="imgix.https.api">
+        <service-type>HTTP</service-type>
+        <enabled>true</enabled>
+        <log-prefix/>
+        <comm-log-enabled>false</comm-log-enabled>
+        <force-prd-enabled>true</force-prd-enabled>
+        <mock-mode-enabled>false</mock-mode-enabled>
+        <profile-id/>
+    </service>
+</services>

--- a/metadata/imgix_data/system-objecttype-extensions.xml
+++ b/metadata/imgix_data/system-objecttype-extensions.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://www.demandware.com/xml/impex/metadata/2006-10-31">
+    <type-extension type-id="SitePreferences">
+        <custom-attribute-definitions>
+            <attribute-definition attribute-id="imgixPageDesignerAPIkey">
+                <display-name xml:lang="x-default">imgix API Key</display-name>
+                <description xml:lang="x-default">The API Key of your imgix account</description>
+                <type>string</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <min-length>0</min-length>
+            </attribute-definition>
+            <attribute-definition attribute-id="imgixPageDesignerSourceName">
+                <display-name xml:lang="x-default">imgix Origin Name</display-name>
+                <description xml:lang="x-default">The Origin Name of your imgix account</description>
+                <type>string</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <min-length>0</min-length>
+            </attribute-definition>
+        </custom-attribute-definitions>
+        <group-definitions>
+            <attribute-group group-id="imgixPageDesigner">
+                <display-name xml:lang="x-default">imgix Page Designer</display-name>
+                <attribute attribute-id="imgixPageDesignerSourceName"/>
+                <attribute attribute-id="imgixPageDesignerAPIkey"/>
+            </attribute-group>
+        </group-definitions>
+    </type-extension>
+</metadata>


### PR DESCRIPTION
This PR creates the necessary `.xml` and `.zip` files so that users can run the 'site import' feature on SFCC to import imgix custom site settings. 

We need these settings in order to pass down an imgix API key to the page designer. These settings will likely be expanded upon in a later commit.