### PR TITLE
[PE-389-1][PE-1517] chore: remove the domain prop

### DIFF
--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -6,4 +6,5 @@ export const parameters = {
       date: /Date$/,
     },
   },
-}
+  layout: "fullscreen",
+};

--- a/frontend/src/components/AssetBrowser/AssetBrowser.tsx
+++ b/frontend/src/components/AssetBrowser/AssetBrowser.tsx
@@ -52,7 +52,7 @@ export function AssetBrowser({
     if (!selectedSource) return;
     // update the cursor position with the offset
     const currentPage = Number(cursor.current) || 0;
-    const limit = cursor.limit || 6;
+    const limit = cursor.limit || 12;
     const delta = offset * limit;
     const nextPage = "" + (currentPage + delta);
     const newCursor = { ...cursor, current: nextPage };

--- a/frontend/src/components/AssetBrowser/AssetBrowser.tsx
+++ b/frontend/src/components/AssetBrowser/AssetBrowser.tsx
@@ -6,6 +6,7 @@ import { SearchBar } from "../forms/search/SearchBar";
 import { SourceSelect } from "../buttons/dropdowns/SourceSelect";
 
 import "../../styles/AssetBrowser.css";
+import Pagination from "../buttons/Pagination";
 interface Props {
   errors: string[];
   loading: boolean;
@@ -125,6 +126,7 @@ export function AssetBrowser({
         loading={loading}
         errors={errors}
       />
+      <Pagination cursor={cursor} handlePageChange={handlePageChange} />
       <div className="ix-asset-meta-information-container"></div>
     </div>
   );

--- a/frontend/src/components/AssetBrowser/AssetBrowser.tsx
+++ b/frontend/src/components/AssetBrowser/AssetBrowser.tsx
@@ -21,6 +21,19 @@ export function AssetBrowser({ apiKey }: Props): ReactElement {
   >();
   const [assets, setAssets] = React.useState<any[]>([]);
 
+  // TODO(luis): refactor this into the searchbar container
+  const handleSearchSubmit = (searchQuery: string) => {
+    if (!!searchQuery && searchQuery.length > 0) {
+      imgixAPI.search
+        .get(apiKey, selectedSource?.id || "", searchQuery)
+        .then((res) => {
+          const searchAssets = res.data;
+          setLoading(false);
+          setAssets(searchAssets);
+        });
+    }
+  };
+
   const handleSourceSelect = (sourceId: string) => {
     setLoading(true);
     // store the selected source and fetch its assets
@@ -97,7 +110,7 @@ export function AssetBrowser({ apiKey }: Props): ReactElement {
     <div className="ix-asset-browser">
       <div className="ix-asset-title-bar-container">
         <SourceSelect sources={sources} handleSelect={handleSourceSelect} />
-        <SearchBar />
+        <SearchBar handleSubmit={handleSearchSubmit} />
       </div>
       <LoadingSpinner loading={loading} />
       {placeholder ? (

--- a/frontend/src/components/AssetBrowser/AssetBrowser.tsx
+++ b/frontend/src/components/AssetBrowser/AssetBrowser.tsx
@@ -30,6 +30,9 @@ export function AssetBrowser({ apiKey }: Props): ReactElement {
           const searchAssets = res.data;
           setLoading(false);
           setAssets(searchAssets);
+        })
+        .catch((err) => {
+          console.log(err);
         });
     }
   };
@@ -62,10 +65,16 @@ export function AssetBrowser({ apiKey }: Props): ReactElement {
     } else {
       setLoading(true);
       // fetch the sources when the component mounts
-      imgixAPI.sources.get(apiKey).then((resp) => {
-        setLoading(false);
-        setSources(resp.data);
-      });
+      imgixAPI.sources
+        .get(apiKey)
+        .then((resp) => {
+          setLoading(false);
+          setSources(resp.data);
+        })
+        .catch((err) => {
+          console.log(err);
+          setLoading(false);
+        });
     }
   }, [apiKey]);
 

--- a/frontend/src/components/AssetBrowser/AssetBrowser.tsx
+++ b/frontend/src/components/AssetBrowser/AssetBrowser.tsx
@@ -74,7 +74,7 @@ export function AssetBrowser({
     setLoading(true);
     // store the selected source and fetch its assets
     const source = sources.find(
-      (currentSource: any) => currentSource.id === sourceId
+      (currentSource: ImgixGETSourcesData[0]) => currentSource.id === sourceId
     );
     if (!source) return;
     setSelectedSource(source);

--- a/frontend/src/components/AssetBrowser/AssetBrowserContainer.tsx
+++ b/frontend/src/components/AssetBrowser/AssetBrowserContainer.tsx
@@ -47,8 +47,6 @@ export class AssetBrowserContainer extends Component<Props, State> {
           errors: [err.message],
           loading: false,
         });
-        // TODO(luis): remove this console.log
-        console.log(err);
       });
   };
 

--- a/frontend/src/components/AssetBrowser/AssetBrowserContainer.tsx
+++ b/frontend/src/components/AssetBrowser/AssetBrowserContainer.tsx
@@ -54,8 +54,9 @@ export class AssetBrowserContainer extends Component<Props, State> {
 
   /**
    *
-   * @param source - the source to request assets from
-   * @param cursor - the cursor to use for pagination
+   * @param params
+   * @param params.source - the source to request assets from
+   * @param [params.cursor] - the cursor to use for pagination
    * @returns {Promise} - A Promise that resolves to the assets from the source
    */
   requestAssets = async ({

--- a/frontend/src/components/AssetBrowser/AssetBrowserContainer.tsx
+++ b/frontend/src/components/AssetBrowser/AssetBrowserContainer.tsx
@@ -163,8 +163,11 @@ export class AssetBrowserContainer extends Component<Props, State> {
     const { apiKey } = this.props;
     const { assets } = this.state;
     if (!apiKey) {
+      // TODO(luis): refactor errors into their own module
       this.setState({
-        errors: ["No API key provided"],
+        errors: [
+          `The API key set for this integration seems to be invalid.\n\nPlease ensure a valid API key is set in your Salesforce Commerce Cloud Site settings\nwhich can be found at Business Manager > [Settings Page] > imgix.`,
+        ],
         loading: false,
       });
     } else if (assets.length === 0) {

--- a/frontend/src/components/AssetBrowser/AssetBrowserContainer.tsx
+++ b/frontend/src/components/AssetBrowser/AssetBrowserContainer.tsx
@@ -1,0 +1,217 @@
+import React, { Component } from "react";
+import { imgixAPI } from "../../services/imgixAPIService";
+import { AssetBrowser } from "./AssetBrowser";
+import { ImgixGETSourcesData, ImgixGETAssetsData, CursorT } from "../../types";
+
+interface Props {
+  apiKey: string;
+}
+
+interface State {
+  errors: string[];
+  loading: boolean;
+  sources: ImgixGETSourcesData;
+  assets: ImgixGETAssetsData;
+  cursor: CursorT;
+  selectedSource: ImgixGETSourcesData[0] | null;
+  query: string;
+}
+
+export class AssetBrowserContainer extends Component<Props, State> {
+  state = {
+    assets: [] as ImgixGETAssetsData,
+    cursor: {} as CursorT,
+    errors: [],
+    loading: true,
+    sources: [] as ImgixGETSourcesData,
+    selectedSource: null,
+    query: "",
+  };
+
+  /**
+   * Request the sources from the imgix API
+   * @returns {Promise} - A promise that resolves when the sources have been
+   * fetched
+   */
+  requestSources = async () => {
+    imgixAPI.sources
+      .get(this.props.apiKey)
+      .then((resp) => {
+        this.setState({
+          sources: resp.data,
+          loading: false,
+        });
+      })
+      .catch((err) => {
+        this.setState({
+          errors: [err.message],
+          loading: false,
+        });
+        // TODO(luis): remove this console.log
+        console.log(err);
+      });
+  };
+
+  /**
+   *
+   * @param source - the source to request assets from
+   * @param cursor - the cursor to use for pagination
+   * @returns {Promise} - A Promise that resolves to the assets from the source
+   */
+  requestAssets = async ({
+    source,
+    cursor,
+  }: {
+    source: ImgixGETSourcesData[0];
+    cursor?: CursorT;
+  }) => {
+    const { apiKey } = this.props;
+
+    return imgixAPI.sources.assets
+      .get(apiKey, source.id, cursor?.current || "0")
+      .then((res) => {
+        this.setState({
+          assets: [...res.data],
+          cursor: res.cursor,
+          loading: false,
+        });
+
+        if (!res.data.length) {
+          throw new Error("Selected source has no assets");
+        }
+      })
+      .catch((err) => {
+        this.setState({
+          errors: [err.message],
+          loading: false,
+        });
+        // TODO(luis): remove this console.log
+        console.log(err);
+      });
+  };
+
+  /**
+   *
+   * @param source - the source to request assets form
+   * @param cursor - the cursor to use for pagination
+   * @param query - the query to use for filtering
+   * @returns {Promise} - A Promise that resolves to the assets from the source
+   * that match the query
+   */
+  searchForAssets = async ({
+    source,
+    cursor,
+    query,
+  }: {
+    source: ImgixGETSourcesData[0];
+    query: string;
+    cursor?: CursorT;
+  }): Promise<void> => {
+    const { apiKey } = this.props;
+    return imgixAPI.search
+      .get(apiKey, source.id, query, cursor?.current || "0")
+      .then((res) => {
+        this.setState({
+          assets: [...res.data],
+          cursor: res.cursor,
+          loading: false,
+        });
+        // raise an error if response has no data
+        if (!res.data.length) {
+          throw new Error("Selected source has no assets");
+        }
+      })
+      .catch((err) => {
+        this.setState({
+          errors: [err.message],
+          loading: false,
+        });
+        // TODO(luis): remove this console.log
+        console.log(err);
+      });
+  };
+
+  /**
+   *
+   * @param source - the source to request assets from
+   * @param cursor - the cursor to use for pagination
+   * @param query - the query to use for filtering
+   * @returns {Promise} - A Promise that resolves to the assets from the source.
+   * If the query is provided, the assets will be filtered by the query. If the
+   * cursor is provided, the assets will be fetched from the cursor position.
+   * Otherwise, the assets will be fetched from the start.
+   */
+  requestAssetsFromSource = async ({
+    source,
+    cursor,
+    query,
+  }: {
+    source: ImgixGETSourcesData[0];
+    cursor?: CursorT;
+    query?: string;
+  }): Promise<void> => {
+    this.setLoading(true);
+    if (!query || query.length === 0) {
+      return this.requestAssets({ source, cursor });
+    }
+    if (query) {
+      this.searchForAssets({ source, cursor, query });
+    }
+  };
+
+  componentDidMount() {
+    // fetch the sources when the component mounts
+    const { apiKey } = this.props;
+    const { assets } = this.state;
+    if (!apiKey) {
+      this.setState({
+        errors: ["No API key provided"],
+        loading: false,
+      });
+    } else if (assets.length === 0) {
+      this.setState({ loading: true }, this.requestSources);
+    }
+  }
+
+  // State setter helper functions, to avoid having to use setState in every
+  // function that needs to update the state.
+
+  setLoading = (loading: boolean) => {
+    this.setState({ loading });
+  };
+
+  setSelectedSource = (source: ImgixGETSourcesData[0]) => {
+    this.setState({ selectedSource: source });
+  };
+
+  setQuery = (query: string) => {
+    this.setState({ query });
+  };
+
+  render() {
+    const {
+      sources,
+      assets,
+      errors,
+      loading,
+      cursor,
+      query,
+      selectedSource,
+    } = this.state;
+    return (
+      <AssetBrowser
+        errors={errors}
+        loading={loading}
+        sources={sources}
+        assets={assets}
+        cursor={cursor}
+        query={query}
+        setQuery={this.setQuery}
+        setLoading={this.setLoading}
+        selectedSource={selectedSource}
+        setSelectedSource={this.setSelectedSource}
+        requestAssetsFromSource={this.requestAssetsFromSource}
+      />
+    );
+  }
+}

--- a/frontend/src/components/buttons/Pagination.tsx
+++ b/frontend/src/components/buttons/Pagination.tsx
@@ -1,0 +1,36 @@
+import React, { ReactElement } from "react";
+import { Button } from "./Button";
+import "../../styles/Pagination.css";
+import { CursorT } from "../../types";
+
+interface Props {
+  cursor: CursorT;
+  handlePageChange: (page: number) => void;
+}
+
+export default function Pagination({
+  cursor,
+  handlePageChange,
+}: Props): ReactElement {
+  let page = parseInt(cursor.current);
+  // never let the page be less than 1
+  if (page < 0) page = 0;
+  // don't render buttons if no assets
+  if (!cursor.totalRecords) return <div />;
+
+  return (
+    <div className="ix-pagination">
+      <div className="ix-pagination-button">
+        {page > 0 && (
+          <Button label="< previous" onClick={() => handlePageChange(-1)} />
+        )}
+      </div>
+
+      <div className="ix-pagination-button">
+        {cursor.next && (
+          <Button label="next >" onClick={() => handlePageChange(1)} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/forms/search/SearchBar.tsx
+++ b/frontend/src/components/forms/search/SearchBar.tsx
@@ -4,11 +4,26 @@ import "../../../styles/Form.css";
 
 interface Props {
   placeholder?: string;
+  handleSubmit: (value: string) => void;
 }
 
-export function SearchBar({ placeholder }: Props): ReactElement {
+export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
+  const [query, setQuery] = React.useState("");
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    setQuery(e.currentTarget.value);
+  };
   return (
-    <form className="ix-asset-simple-search-content">
+    <form
+      className="ix-asset-simple-search-content"
+      onSubmit={(e) => {
+        // Prevent the form from submitting, i.e. reloading the page
+        e.preventDefault();
+        // Call the handleSubmit function that was passed through props
+        handleSubmit(query);
+      }}
+    >
       <div className="ix-asset-simple-search-wrapper">
         <div className="ix-asset-simple-search-base">
           <div className="ix-asset-simple-search-base-input">
@@ -21,6 +36,15 @@ export function SearchBar({ placeholder }: Props): ReactElement {
               placeholder={
                 placeholder ? placeholder : "Search filename or path"
               }
+              value={query}
+              onChange={(event) => {
+                event.preventDefault();
+                handleInputChange(event);
+              }}
+              onSubmit={(event) => {
+                event.preventDefault();
+                handleSubmit(query);
+              }}
             />
           </div>
         </div>

--- a/frontend/src/components/forms/search/SearchBar.tsx
+++ b/frontend/src/components/forms/search/SearchBar.tsx
@@ -42,6 +42,8 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
                 handleInputChange(event);
               }}
               onSubmit={(event) => {
+                // TODO(luis): Remove this. This is a hack to prevent the form
+                // from submitting
                 event.preventDefault();
                 handleSubmit(query);
               }}

--- a/frontend/src/components/grids/AssetGrid.tsx
+++ b/frontend/src/components/grids/AssetGrid.tsx
@@ -5,9 +5,14 @@ import "../../styles/Grid.css";
 interface Props {
   assets: ImgixGETAssetsData;
   domain: string;
+  placeholder: string | ReactElement;
 }
 // TODO(luis): refactor this component into smaller components
-export function AssetGrid({ assets, domain }: Props): ReactElement {
+export function AssetGrid({
+  assets,
+  domain,
+  placeholder,
+}: Props): ReactElement {
   // create grid-items
   const gridItems = assets.map((asset, idx) => {
     return (
@@ -30,5 +35,17 @@ export function AssetGrid({ assets, domain }: Props): ReactElement {
     );
   });
   // create the asset grid
-  return <div className="ix-grid">{gridItems}</div>;
+  return (
+    <div className="ix-grid">
+      {!!gridItems.length ? (
+        gridItems
+      ) : (
+        <div className="ix-grid ix-grid-item-placeholder ">
+          <div>
+            <div>{placeholder}</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/components/grids/AssetGrid.tsx
+++ b/frontend/src/components/grids/AssetGrid.tsx
@@ -14,8 +14,7 @@ export function AssetGrid({ assets, domain }: Props): ReactElement {
       <div className="ix-grid-item" key={`${asset.id}-${idx}`}>
         <div className="ix-grid-item-image">
           <Imgix
-            domain={domain}
-            src={asset.attributes.origin_path}
+            src={"https://" + domain + asset.attributes.origin_path}
             width={340}
             height={340}
             imgixParams={{

--- a/frontend/src/components/grids/AssetGrid.tsx
+++ b/frontend/src/components/grids/AssetGrid.tsx
@@ -1,16 +1,22 @@
 import React, { ReactElement } from "react";
 import Imgix from "react-imgix";
 import { ImgixGETAssetsData } from "../../types";
+import { LoadingSpinner } from "../LoadingSpinner";
 import "../../styles/Grid.css";
+
 interface Props {
   assets: ImgixGETAssetsData;
   domain: string;
-  placeholder: string | ReactElement;
+  errors: string[];
+  loading: boolean;
+  placeholder?: string;
 }
 // TODO(luis): refactor this component into smaller components
 export function AssetGrid({
   assets,
   domain,
+  errors,
+  loading,
   placeholder,
 }: Props): ReactElement {
   // create grid-items
@@ -34,18 +40,34 @@ export function AssetGrid({
       </div>
     );
   });
-  // create the asset grid
-  return (
-    <div className="ix-grid">
-      {!!gridItems.length ? (
-        gridItems
-      ) : (
-        <div className="ix-grid ix-grid-item-placeholder ">
-          <div>
-            <div>{placeholder}</div>
-          </div>
+  // show grid error message if error
+  if (errors.length > 0) {
+    const message = errors.pop();
+    return (
+      <div className="ix-grid-item-placeholder error">
+        <div>{message}</div>
+      </div>
+    );
+  }
+  // show grid placeholder if no assets
+  else if (!assets.length && !loading) {
+    return (
+      <div className="ix-grid-item-placeholder">
+        <div>{placeholder || "Select a source"}</div>
+      </div>
+    );
+  }
+  // show loading indicator if loading
+  if (loading) {
+    return (
+      <div className="ix-grid-item-placeholder loading">
+        <div>
+          <LoadingSpinner loading={loading} />
         </div>
-      )}
-    </div>
-  );
+      </div>
+    );
+  }
+
+  // create the asset grid
+  return <div className="ix-grid">{gridItems}</div>;
 }

--- a/frontend/src/components/grids/AssetGrid.tsx
+++ b/frontend/src/components/grids/AssetGrid.tsx
@@ -36,7 +36,9 @@ export function AssetGrid({
             sizes="(min-width: 480px) calc(12.5vw - 20px)"
           />
         </div>
-        <p className="ix-grid-item-filename">{asset.attributes.origin_path}</p>
+        <p className="ix-grid-item-filename">
+          {domain + asset.attributes.origin_path}
+        </p>
       </div>
     );
   });

--- a/frontend/src/services/imgixAPIService.ts
+++ b/frontend/src/services/imgixAPIService.ts
@@ -67,7 +67,7 @@ export const imgixAPI = {
         apiKey: string,
         sourceId: string,
         index: string = "0",
-        size: string = "6"
+        size: string = "12"
       ) {
         // ?page[number]=${n}&page[size]=18`
         return await makeRequest<ImgixGETAssetsData>({
@@ -90,7 +90,7 @@ export const imgixAPI = {
       sourceId: string,
       query: string,
       index: string = "0",
-      size: string = "6"
+      size: string = "12"
     ) {
       // TODO(luis): use a search endpoint rather than the assets endpoint
       // build the filter portion of the query

--- a/frontend/src/services/imgixAPIService.ts
+++ b/frontend/src/services/imgixAPIService.ts
@@ -65,4 +65,34 @@ export const imgixAPI = {
       },
     },
   },
+  search: {
+    /**
+     * Search for images in the current imgix account
+     * @param apiKey - The imgix API key to be used for the request
+     * @param query - The query to search for
+     * @returns An `data` array of asset objects and a `meta` object with
+     * pagination information
+     */
+    async get(apiKey: string, sourceId: string, query: string) {
+      // TODO(luis): use a search endpoint rather than the assets endpoint
+      // build the filter portion of the query
+      const categories = `filter%5Bor:categories%5D=${query}`;
+      const keywords = `&filter%5Bor:keywords%5D=${query}`;
+      const origin_path = `&filter%5Bor:origin_path%5D=${query}`;
+      const filter = categories + keywords + origin_path;
+      // build the paging portion of the query
+      const pageCursor = `page%5Bcursor%5D=0`;
+      const pageLimit = `page%5Blimit%5D=60`;
+      // build the sorting portion of the query
+      const sortBy = `sort=-date_created`;
+      // TODO(luis): is this fields param necessary?
+      // build the fields portion of the query
+      // const fields = `fields[assets]=name,description,origin_path`;
+
+      return await makeRequest<ImgixGETAssetsData>({
+        url: `assets/${sourceId}?${filter}&${pageCursor}&${pageLimit}&${sortBy}`,
+        apiKey,
+      });
+    },
+  },
 };

--- a/frontend/src/stories/AssetBrowser.tsx
+++ b/frontend/src/stories/AssetBrowser.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { AssetBrowser as _AssetBrowser } from "../components/AssetBrowser/AssetBrowser";
+import { AssetBrowserContainer as _AssetBrowser } from "../components/AssetBrowser/AssetBrowserContainer";
 
 interface Props {
   apiKey: string;

--- a/frontend/src/stories/AssetGrid.stories.tsx
+++ b/frontend/src/stories/AssetGrid.stories.tsx
@@ -17,32 +17,32 @@ BasicGrid.args = {
   assets: [
     {
       attributes: {
-        origin_path: "amsterdam.jpg",
+        origin_path: "/amsterdam.jpg",
       },
     } as any,
     {
       attributes: {
-        origin_path: "amsterdam.jpg",
+        origin_path: "/amsterdam.jpg",
       },
     } as any,
     {
       attributes: {
-        origin_path: "amsterdam.jpg",
+        origin_path: "/amsterdam.jpg",
       },
     } as any,
     {
       attributes: {
-        origin_path: "amsterdam.jpg",
+        origin_path: "/amsterdam.jpg",
       },
     } as any,
     {
       attributes: {
-        origin_path: "amsterdam.jpg",
+        origin_path: "/amsterdam.jpg",
       },
     } as any,
     {
       attributes: {
-        origin_path: "amsterdam.jpg",
+        origin_path: "/amsterdam.jpg",
       },
     } as any,
   ] as any,

--- a/frontend/src/stories/AssetGrid.tsx
+++ b/frontend/src/stories/AssetGrid.tsx
@@ -9,7 +9,13 @@ interface Props {
 export function AssetGrid({ assets, domain }: Props): ReactElement {
   return (
     <div className="ix-grid-container">
-      <_AssetGrid domain={domain} assets={assets} placeholder={"loading..."} />
+      <_AssetGrid
+        domain={domain}
+        assets={assets}
+        placeholder={"loading..."}
+        errors={[]}
+        loading={false}
+      />
     </div>
   );
 }

--- a/frontend/src/stories/AssetGrid.tsx
+++ b/frontend/src/stories/AssetGrid.tsx
@@ -9,7 +9,7 @@ interface Props {
 export function AssetGrid({ assets, domain }: Props): ReactElement {
   return (
     <div className="ix-grid-container">
-      <_AssetGrid domain={domain} assets={assets} />
+      <_AssetGrid domain={domain} assets={assets} placeholder={"loading..."} />
     </div>
   );
 }

--- a/frontend/src/stories/SearchBar.tsx
+++ b/frontend/src/stories/SearchBar.tsx
@@ -6,12 +6,15 @@ interface Props {
 }
 
 export function SearchBar({ placeholder }: Props): ReactElement {
+  const handleSubmit = (value: string) => {
+    console.log(`handleSubmit:`, value);
+  };
   return (
     <div
       style={{ margin: 5, position: "relative" }}
       className="ix-searchbar-container"
     >
-      <_SearchBar placeholder={placeholder} />
+      <_SearchBar handleSubmit={handleSubmit} placeholder={placeholder} />
     </div>
   );
 }

--- a/frontend/src/styles/AssetBrowser.css
+++ b/frontend/src/styles/AssetBrowser.css
@@ -37,6 +37,10 @@
   grid-column-start: 1;
   grid-column-end: 4;
 }
+.error {
+  /* have text wrap into new lines */
+  white-space: pre-wrap;
+}
 /* style the loading placeholder for the asset grid */
 .ix-asset-grid-loading {
   grid-column: 2;

--- a/frontend/src/styles/AssetBrowser.css
+++ b/frontend/src/styles/AssetBrowser.css
@@ -29,7 +29,6 @@
 .ix-grid-item-placeholder {
   margin: 32px;
   height: 250px;
-  border: 2px solid #eeeded;
   border-radius: 4px;
   display: flex;
   background: #fafafa;

--- a/frontend/src/styles/AssetBrowser.css
+++ b/frontend/src/styles/AssetBrowser.css
@@ -31,7 +31,7 @@
   height: 250px;
   border-radius: 4px;
   display: flex;
-  background: #fafafa;
+  background: #e3e7eb;
   justify-content: center;
   align-items: center;
   grid-column-start: 1;

--- a/frontend/src/styles/Form.css
+++ b/frontend/src/styles/Form.css
@@ -75,6 +75,7 @@
   left: 52px;
   right: 50px;
   height: 100%;
+  min-width: 200px;
   overflow: hidden;
   display: flex;
   align-items: center;

--- a/frontend/src/styles/Grid.css
+++ b/frontend/src/styles/Grid.css
@@ -6,26 +6,27 @@
 }
 
 .ix-grid {
+  padding: 15px;
   display: grid;
   grid-gap: 20px;
   justify-items: stretch;
   align-items: start;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(6, 1fr);
 }
-@media (min-width: 900px) {
+@media (max-width: 900px) {
   .ix-grid {
     grid-template-columns: repeat(4, 1fr);
   }
 }
 
-@media (min-width: 694px) {
-  .ix-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-@media (min-width: 540px) {
+@media (max-width: 694px) {
   .ix-grid {
     grid-template-columns: repeat(3, 1fr);
+  }
+}
+@media (max-width: 540px) {
+  .ix-grid {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
@@ -34,6 +35,12 @@
   cursor: pointer;
   border-radius: 2px;
   overflow: hidden;
+  max-height: 340px;
+  max-width: 340px;
+}
+
+.ix-grid-item:hover {
+  box-shadow: 0 0 0 2px rgb(0 191 254 / 40%);
 }
 
 .ix-grid-item-image {
@@ -50,7 +57,26 @@
 }
 
 .ix-grid-item-filename {
+  display: flex;
+  justify-content: flex-end;
+  flex: 0 1 auto;
+  font-size: 14px;
+  line-height: 20px;
+  color: #6c7f8e;
+  font-weight: 400;
+  white-space: nowrap;
   position: relative;
   padding: 6px 10px;
   margin: 0px;
+}
+
+.ix-grid-item-filename:before {
+  content: " ";
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 20px;
+  background: linear-gradient(90deg, #fff 25%, #fff);
+  background: linear-gradient(90deg, #fff 25%, hsla(0, 0%, 100%, 0));
 }

--- a/frontend/src/styles/LoadingSpinner.css
+++ b/frontend/src/styles/LoadingSpinner.css
@@ -9,7 +9,7 @@
 .ix-loading-indicator {
   width: 50px;
   height: 50px;
-  border: 3px solid rgba(255, 255, 255, 0.3);
+  border: 3px solid rgb(227 231 235);
   border-radius: 50%;
   border-top-color: #fff;
   animation: spin 1s ease-in-out infinite;

--- a/frontend/src/styles/Pagination.css
+++ b/frontend/src/styles/Pagination.css
@@ -1,0 +1,6 @@
+.ix-pagination {
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-evenly;
+  margin-top: 25px;
+}

--- a/frontend/src/types/cursor.ts
+++ b/frontend/src/types/cursor.ts
@@ -1,0 +1,7 @@
+export type CursorT = {
+  current: string;
+  next: string;
+  limit?: number;
+  hasMore: boolean;
+  totalRecords: number;
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,1 +1,2 @@
 export type { ImgixGETSourcesData, ImgixGETAssetsData } from "./imgixAPITypes";
+export type { CursorT } from "./cursor";


### PR DESCRIPTION
This commit removes the `domain` prop from the `Imgix` component to fix an issue with the types. The `@types/react-imgix` repo doesn't yet have the new `domain` prop defined.

<!---GHSTACKOPEN-->
### Stacked PR Chain: PE-389-1
| PR | Title |  Merges Into  |
|:--:|:------|:-------------:|
|#49|[PE-389-1][PE-1531] feat: add loading state to asset grid|**N/A**|
|#51|[PE-389-1][PE-1517] chore: remove the domain prop|#49|
|#52|[PE-389-1][PE-1527] feat: add search to asset browser|#51|
|#53|[PE-389-1][PE-1528] feat: catch and display imgixAPI errors|#52|
|#54|[PE-389-1][PE-1526] feat: add pagination|#53|
|#55|[PE-389-1][PE-1526-1] chore: update grid style to show more assets|#54|

<!---GHSTACKCLOSE-->

