### PR TITLE
[PE-389-1][PE-1526-1] chore: update grid style to show more assets

### DIFF
--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -6,4 +6,5 @@ export const parameters = {
       date: /Date$/,
     },
   },
-}
+  layout: "fullscreen",
+};

--- a/frontend/src/components/AssetBrowser/AssetBrowser.tsx
+++ b/frontend/src/components/AssetBrowser/AssetBrowser.tsx
@@ -52,7 +52,7 @@ export function AssetBrowser({
     if (!selectedSource) return;
     // update the cursor position with the offset
     const currentPage = Number(cursor.current) || 0;
-    const limit = cursor.limit || 6;
+    const limit = cursor.limit || 12;
     const delta = offset * limit;
     const nextPage = "" + (currentPage + delta);
     const newCursor = { ...cursor, current: nextPage };

--- a/frontend/src/components/grids/AssetGrid.tsx
+++ b/frontend/src/components/grids/AssetGrid.tsx
@@ -36,7 +36,9 @@ export function AssetGrid({
             sizes="(min-width: 480px) calc(12.5vw - 20px)"
           />
         </div>
-        <p className="ix-grid-item-filename">{asset.attributes.origin_path}</p>
+        <p className="ix-grid-item-filename">
+          {domain + asset.attributes.origin_path}
+        </p>
       </div>
     );
   });

--- a/frontend/src/services/imgixAPIService.ts
+++ b/frontend/src/services/imgixAPIService.ts
@@ -67,7 +67,7 @@ export const imgixAPI = {
         apiKey: string,
         sourceId: string,
         index: string = "0",
-        size: string = "6"
+        size: string = "12"
       ) {
         // ?page[number]=${n}&page[size]=18`
         return await makeRequest<ImgixGETAssetsData>({
@@ -90,7 +90,7 @@ export const imgixAPI = {
       sourceId: string,
       query: string,
       index: string = "0",
-      size: string = "6"
+      size: string = "12"
     ) {
       // TODO(luis): use a search endpoint rather than the assets endpoint
       // build the filter portion of the query

--- a/frontend/src/styles/AssetBrowser.css
+++ b/frontend/src/styles/AssetBrowser.css
@@ -31,7 +31,7 @@
   height: 250px;
   border-radius: 4px;
   display: flex;
-  background: #fafafa;
+  background: #e3e7eb;
   justify-content: center;
   align-items: center;
   grid-column-start: 1;

--- a/frontend/src/styles/Grid.css
+++ b/frontend/src/styles/Grid.css
@@ -6,26 +6,27 @@
 }
 
 .ix-grid {
+  padding: 15px;
   display: grid;
   grid-gap: 20px;
   justify-items: stretch;
   align-items: start;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(6, 1fr);
 }
-@media (min-width: 900px) {
+@media (max-width: 900px) {
   .ix-grid {
     grid-template-columns: repeat(4, 1fr);
   }
 }
 
-@media (min-width: 694px) {
-  .ix-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-@media (min-width: 540px) {
+@media (max-width: 694px) {
   .ix-grid {
     grid-template-columns: repeat(3, 1fr);
+  }
+}
+@media (max-width: 540px) {
+  .ix-grid {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
@@ -34,6 +35,12 @@
   cursor: pointer;
   border-radius: 2px;
   overflow: hidden;
+  max-height: 340px;
+  max-width: 340px;
+}
+
+.ix-grid-item:hover {
+  box-shadow: 0 0 0 2px rgb(0 191 254 / 40%);
 }
 
 .ix-grid-item-image {
@@ -50,7 +57,26 @@
 }
 
 .ix-grid-item-filename {
+  display: flex;
+  justify-content: flex-end;
+  flex: 0 1 auto;
+  font-size: 14px;
+  line-height: 20px;
+  color: #6c7f8e;
+  font-weight: 400;
+  white-space: nowrap;
   position: relative;
   padding: 6px 10px;
   margin: 0px;
+}
+
+.ix-grid-item-filename:before {
+  content: " ";
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 20px;
+  background: linear-gradient(90deg, #fff 25%, #fff);
+  background: linear-gradient(90deg, #fff 25%, hsla(0, 0%, 100%, 0));
 }


### PR DESCRIPTION
This PR changes `AssetGrid` styling so that more assets are displayed per page by default. It also changes the `storybook` styling so that the pages have no padding.

## Video 📹

https://user-images.githubusercontent.com/16711614/139305499-6ec03793-ff34-4609-b9a3-abb30c1df42f.mov


https://user-images.githubusercontent.com/16711614/139305516-f3cf9257-5eec-476a-9ad4-e8cb83ee3e3c.mov




<!---GHSTACKOPEN-->
### Stacked PR Chain: PE-389-1
| PR | Title |  Merges Into  |
|:--:|:------|:-------------:|
|#49|[PE-389-1][PE-1531] feat: add loading state to asset grid|**N/A**|
|#51|[PE-389-1][PE-1517] chore: remove the domain prop|#49|
|#52|[PE-389-1][PE-1527] feat: add search to asset browser|#51|
|#53|[PE-389-1][PE-1528] feat: catch and display imgixAPI errors|#52|
|#54|[PE-389-1][PE-1526] feat: add pagination|#53|
|#55|[PE-389-1][PE-1526-1] chore: update grid style to show more assets|#54|

<!---GHSTACKCLOSE-->
