### PR TITLE
build(PE-1518): change css bundle filename

### DIFF
--- a/frontend/config-overrides.js
+++ b/frontend/config-overrides.js
@@ -1,9 +1,19 @@
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+
 module.exports = function override(config, env) {
+  console.log(env);
   config.optimization.splitChunks = {
     cacheGroups: {
       default: false,
     },
   };
+  const appName = process.env.REACT_APP_APP_TYPE || "react";
   config.optimization.runtimeChunk = false;
+  config.output.filename = `js/${appName}.js`;
+  config.plugins.push(
+    new MiniCssExtractPlugin({
+      filename: `css/${appName}.css`,
+    })
+  );
   return config;
 };

--- a/frontend/config-overrides.js
+++ b/frontend/config-overrides.js
@@ -1,7 +1,6 @@
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 module.exports = function override(config, env) {
-  console.log(env);
   config.optimization.splitChunks = {
     cacheGroups: {
       default: false,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,6 +79,7 @@
     "@types/jsuri": "^1.3.30",
     "@types/react-imgix": "^9.2.0",
     "jsuri": "^1.3.1",
+    "mini-css-extract-plugin": "0.9.0",
     "ts-jest": "^27.0.5"
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9765,6 +9765,16 @@ mini-css-extract-plugin@0.11.3:
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 
+mini-css-extract-plugin@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz#47f2cf07aa165ab35733b1fc97d4c46c0564339e"
+  integrity sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==
+  dependencies:
+    loader-utils "^1.1.0"
+    normalize-url "1.9.1"
+    schema-utils "^1.0.0"
+    webpack-sources "^1.1.0"
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"


### PR DESCRIPTION
This commit uses the `mini-css-extract-plugin` to give the react app CSS bundles a predictable and unique filename. This is done so that a future build script can reference this filename when copying over the styles into the sfcc cartridge.