### PR TITLE
chore: use @imgix/js-core to build image src

### DIFF
--- a/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
+++ b/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
@@ -2,6 +2,7 @@
 var Template = require("dw/util/Template");
 var HashMap = require("dw/util/HashMap");
 var Logger = require("dw/system/Logger");
+var ImgixClient = require("*/cartridge/scripts/jsCore/jsCore");
 
 // handle function for component.
 module.exports.render = function (context, modelIn) {
@@ -16,8 +17,9 @@ module.exports.render = function (context, modelIn) {
   // use to give link on the image, if we click on image it take to us to that page.
   model.link = content.imageLink ? content.imageLink : "#";
   model.alt = content.alt ? content.alt : null;
-  model.image_src =
+  const rawImageUrl =
     content.image_url || "https://assets.imgix.net/amsterdam.jpg?w=500";
+  model.image_src = ImgixClient._buildURL(rawImageUrl, { txt: "Hello World" });
 
   return new Template("/experience/components/imgix/imageComponent").render(
     model


### PR DESCRIPTION
Uses @imgix/js-core to build the image src for the rendered image. Pretty self-explanatory here. Will be extended in due course to generate the srcset, etc.