### PR TITLE
chore(PE-111-1): remove handle-breakout-cancel

### DIFF
--- a/frontend/src/index-sidebar.tsx
+++ b/frontend/src/index-sidebar.tsx
@@ -53,17 +53,10 @@ export const createSidebarApp = () => {
         });
       }
 
-      function handleBreakoutCancel() {
-        // Grab focus
-        // TODO: grab reference to the cancel button and handle cancel event
-      }
-
       function handleBreakoutClose({ type, value }: any) {
         // Now the "value" can be passed back to Page Designer
         if (type === "sfcc:breakoutApply") {
           handleBreakoutApply(value);
-        } else {
-          handleBreakoutCancel();
         }
       }
 


### PR DESCRIPTION
The handleBreakoutCancel CB is never called in the side-bar react application. Therefore, we can safely remove the function.
<!---GHSTACKOPEN-->
### Stacked PR Chain: PE-111-1
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#70|*(Draft) chore(PE-111-1): add sfcc-ready type declaration*|Pending|-|
|#71|*(Draft) chore(PE-111-1): remove unsused variable and type*|Pending|#70|
|#72|👉 *(Draft) chore(PE-111-1): remove handle-breakout-cancel*|Pending|#71|

<!---GHSTACKCLOSE-->
