### PR TITLE
chore: declare sfcc ready payload types

### DIFF
--- a/frontend/src/index-sidebar.tsx
+++ b/frontend/src/index-sidebar.tsx
@@ -21,7 +21,15 @@ export const createSidebarApp = () => {
       isRequired,
       dataLocale,
       displayLocale,
-    }: any) => {
+    }: {
+      value: any;
+      config: any;
+      isRequired: boolean;
+      isDisabled: boolean;
+      isValid: boolean;
+      dataLocale: string;
+      displayLocale: string;
+    }) => {
       // TODO: remove this log
       console.log(
         "sidebar-trigger::sfcc:ready",


### PR DESCRIPTION
This PR adds typing to the `payload` object for the `sfcc:ready` event.