### PR TITLE
chore(PE-1574): add typing declaration to subscribe func

### DIFF
--- a/frontend/src/index-sidebar.tsx
+++ b/frontend/src/index-sidebar.tsx
@@ -14,7 +14,6 @@ var rootEditorElement;
 
 export const createSidebarApp = () => {
   let localization: any;
-  let buttonEl: any;
 
   subscribe(
     "sfcc:ready",
@@ -38,18 +37,10 @@ export const createSidebarApp = () => {
         });
       }
 
-      function handleBreakoutCancel(value: any) {
-        // Grab focus
-        console.log(value, " from cancel");
-        buttonEl && buttonEl.focus();
-      }
-
       function handleBreakoutClose({ type, value }: any) {
         // Now the "value" can be passed back to Page Designer
         if (type === "sfcc:breakoutApply") {
           handleBreakoutApply(value);
-        } else {
-          handleBreakoutCancel(value);
         }
       }
 

--- a/frontend/src/index-sidebar.tsx
+++ b/frontend/src/index-sidebar.tsx
@@ -3,8 +3,10 @@ import ReactDOM from "react-dom";
 import { App } from "./components";
 import "./styles/index.css";
 
+import { SandboxSubscribe } from "./types";
+
 declare const emit: Function;
-declare const subscribe: Function;
+declare const subscribe: SandboxSubscribe;
 
 var rootEditorElement;
 
@@ -26,7 +28,7 @@ export const createSidebarApp = () => {
       ({ localization = {} } = config);
 
       function handleBreakoutApply(value: any) {
-          console.log(value, ' from apply')
+        console.log(value, " from apply");
         // Emit value update to Page Designer host application
         emit({
           type: "sfcc:value",
@@ -36,7 +38,7 @@ export const createSidebarApp = () => {
 
       function handleBreakoutCancel(value: any) {
         // Grab focus
-          console.log(value, ' from cancel')
+        console.log(value, " from cancel");
         buttonEl && buttonEl.focus();
       }
 

--- a/frontend/src/index-sidebar.tsx
+++ b/frontend/src/index-sidebar.tsx
@@ -6,7 +6,9 @@ import "./styles/index.css";
 import { SandboxSubscribe } from "./types";
 
 declare const emit: Function;
-declare const subscribe: SandboxSubscribe;
+declare const subscribe: SandboxSubscribe<
+  Record<string, string | number | object>
+>;
 
 var rootEditorElement;
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,2 +1,3 @@
 export type { ImgixGETSourcesData, ImgixGETAssetsData } from "./imgixAPITypes";
 export type { CursorT } from "./cursor";
+export type { SandboxSubscribe } from "./sfcc";

--- a/frontend/src/types/sfcc.ts
+++ b/frontend/src/types/sfcc.ts
@@ -3,9 +3,8 @@ export type SandboxSubscribe = (
   type: string,
   callback: (
     payload: {
-      // value is user defined, can be anything
+      // config and value are user defined, can be anything
       value: Object;
-      // config is user defined, can be anything
       config: {
         [key: string]: any;
       };

--- a/frontend/src/types/sfcc.ts
+++ b/frontend/src/types/sfcc.ts
@@ -1,0 +1,26 @@
+// subscribe:Interface
+export type SandboxSubscribe = (
+  type: string,
+  callback: (
+    payload: {
+      // value is user defined, can be anything
+      value: Object;
+      // config is user defined, can be anything
+      config: {
+        [key: string]: any;
+      };
+      isRequired: boolean;
+      isDisabled: boolean;
+      isValid: boolean;
+      dataLocale: string;
+      displayLocale: string;
+    },
+    context?: SandboxContext
+  ) => void,
+  source?: any
+) => () => void;
+
+export interface SandboxContext {
+  transfer?: Transferable[]; // @see https://developer.mozilla.org/en-US/docs/Web/API/Transferable
+  source?: any; // Event sourcing should only be required in rare cases
+}

--- a/frontend/src/types/sfcc.ts
+++ b/frontend/src/types/sfcc.ts
@@ -1,13 +1,11 @@
 // subscribe:Interface
-export type SandboxSubscribe = (
+export type SandboxSubscribe<Config extends Record<string, any>> = (
   type: string,
   callback: (
     payload: {
       // config and value are user defined, can be anything
       value: Object;
-      config: {
-        [key: string]: any;
-      };
+      config: Config;
       isRequired: boolean;
       isDisabled: boolean;
       isValid: boolean;


### PR DESCRIPTION
This commit defines the SFCC `subscribe` function types. The types were taken from the SFCC [documentation](https://documentation.b2c.commercecloud.salesforce.com/DOC4/index.jsp?topic=%2Fcom.demandware.dochelp%2Fcontent%2Fb2c_commerce%2Ftopics%2Fpage_designer%2Fb2c_host_events_custom_attr_editor.html) since the function is injected at runtime and the types cannot be inferred.

<!---GHSTACKOPEN-->
### Stacked PR Chain: PE-1574
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#74|👉 chore(PE-1574): add typing declaration to subscribe func|**Approved**|-|
|#75|chore(PE-1574): remove unused function and variable|**Approved**|#74|

<!---GHSTACKCLOSE-->

