### PR TITLE
chore(PE-1574): remove unused function and variable

### DIFF
--- a/frontend/src/index-sidebar.tsx
+++ b/frontend/src/index-sidebar.tsx
@@ -14,7 +14,6 @@ var rootEditorElement;
 
 export const createSidebarApp = () => {
   let localization: any;
-  let buttonEl: any;
 
   subscribe(
     "sfcc:ready",
@@ -38,18 +37,10 @@ export const createSidebarApp = () => {
         });
       }
 
-      function handleBreakoutCancel(value: any) {
-        // Grab focus
-        console.log(value, " from cancel");
-        buttonEl && buttonEl.focus();
-      }
-
       function handleBreakoutClose({ type, value }: any) {
         // Now the "value" can be passed back to Page Designer
         if (type === "sfcc:breakoutApply") {
           handleBreakoutApply(value);
-        } else {
-          handleBreakoutCancel(value);
         }
       }
 


### PR DESCRIPTION
This commit removes the unused variable `buttonEl` and the handleBreakoutCancel function. The handleBreakoutCancel is automatically emited by the SFCC framework and does not need to be defined.

<!---GHSTACKOPEN-->
### Stacked PR Chain: PE-1574
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#74|chore(PE-1574): add typing declaration to subscribe func|**Approved**|-|
|#75|👉 chore(PE-1574): remove unused function and variable|**Approved**|#74|

<!---GHSTACKCLOSE-->

