### PR TITLE
feat: connect modal to salesforce data flow on SF side - DON'T merge, only for tutorial

### DIFF
--- a/frontend/src/components/BreakoutApp.tsx
+++ b/frontend/src/components/BreakoutApp.tsx
@@ -7,6 +7,7 @@ export function App({ apiKey }: { apiKey: string | null }) {
       <header className="App-header">
         <AssetBrowser apiKey={apiKey} />
       </header>
+      <div></div>
     </div>
   );
 }

--- a/frontend/src/components/BreakoutApp.tsx
+++ b/frontend/src/components/BreakoutApp.tsx
@@ -8,6 +8,7 @@ export function App({ apiKey }: { apiKey: string | null }) {
         <AssetBrowser apiKey={apiKey} />
       </header>
       <div></div>
+      <div></div>
     </div>
   );
 }

--- a/frontend/src/index-sidebar.tsx
+++ b/frontend/src/index-sidebar.tsx
@@ -44,8 +44,9 @@ export const createSidebarApp = () => {
         });
       }
 
-      function handleBreakoutCancel() {
+      function handleBreakoutCancel(value: any) {
         // Grab focus
+        console.log(value, " from cancel");
         buttonEl && buttonEl.focus();
       }
 


### PR DESCRIPTION
This PR connects the modal to the SF data flow on the SF side, and is expected to be extended/integrated into the React flow. 