### PR TITLE
[fred] feat: add imgix parameters to component sidebar

### DIFF
--- a/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.json
+++ b/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.json
@@ -49,21 +49,21 @@
         {
           "id": "fm",
           "name": "Format",
-          "description": "The format to apply to the image. It is recommended to use the auto parameter to set format, by including 'format' in the setting above. If set, this will override auto-formatting",
+          "description": "The format to apply to the image. It is recommended to use the auto parameter to set format, by including 'format' in the setting above. If set, this will override auto-formatting. For more information, see: https://docs.imgix.com/apis/rendering/format",
           "type": "string",
           "required": false
         },
         {
           "id": "auto",
           "name": "Auto",
-          "description": "The automatic parameters to apply to the image. Values should be separated with a comma, e.g. 'format,compress'. Default recommended is 'format,compress'",
+          "description": "The automatic parameters to apply to the image. Values should be separated with a comma, e.g. 'format,compress'. Default recommended is 'format,compress'. For more information, see: https://docs.imgix.com/apis/rendering/auto/auto",
           "type": "string",
           "required": false
         },
         {
           "id": "crop",
           "name": "Crop",
-          "description": "The crop parameter to apply to the image. The default is 'clip'.",
+          "description": "The crop parameter to apply to the image. For more information, see: https://docs.imgix.com/apis/rendering/size/crop",
           "type": "string",
           "required": false
         }

--- a/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.json
+++ b/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.json
@@ -31,6 +31,41 @@
           "description": "The sizes attribute for the image to help the image behave responsibly. If the image is a fixed size, set this to the image width.",
           "type": "string",
           "required": false
+        },
+        {
+          "id": "width",
+          "name": "Width",
+          "description": "The width of the image in pixels. If set, will make the image render at fixed-size, making sizes have no effect",
+          "type": "integer",
+          "required": false
+        },
+        {
+          "id": "height",
+          "name": "Height",
+          "description": "The height of the image in pixels. If set, will make the image render at fixed-size, making sizes have no effect",
+          "type": "integer",
+          "required": false
+        },
+        {
+          "id": "fm",
+          "name": "Format",
+          "description": "The format to apply to the image. It is recommended to use the auto parameter to set format, by including 'format' in the setting above. If set, this will override auto-formatting",
+          "type": "string",
+          "required": false
+        },
+        {
+          "id": "auto",
+          "name": "Auto",
+          "description": "The automatic parameters to apply to the image. Values should be separated with a comma, e.g. 'format,compress'. Default recommended is 'format,compress'",
+          "type": "string",
+          "required": false
+        },
+        {
+          "id": "crop",
+          "name": "Crop",
+          "description": "The crop parameter to apply to the image. The default is 'clip'.",
+          "type": "string",
+          "required": false
         }
       ]
     }


### PR DESCRIPTION
This PR adds the imgix parameters to the sidebar according to the requirements. I'm just using basic types (strings, numbers), for now, but this can be upgraded in the future to use enums

![image](https://user-images.githubusercontent.com/615334/141499722-9d736e39-c1d5-4d26-a687-152cdf4a88c1.png)


<!---GHSTACKOPEN-->
### Stacked PR Chain: fred
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#76|feat: implement responsive images and set ixlib|Pending|-|
|#77|chore: write template logic to handle default params|Pending|#76|
|#82|👉 feat: add imgix parameters to component sidebar|Pending|#77|
|#79|Added apikey to defaultParams|Pending|#77|
|#83|feat: correctly set imgix parameters on rendered image|Pending|#82|

<!---GHSTACKCLOSE-->

