### PR TITLE
chore: update imgix component data type of SF side and access

### DIFF
--- a/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
+++ b/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
@@ -44,7 +44,8 @@ module.exports.render = function (context, modelIn) {
 
   // TODO: delete raw image URL when component data pipeline works
   const rawImageUrl =
-    content.image_url || "https://assets.imgix.net/amsterdam.jpg";
+    (content.image_data && content.image_data.src) ||
+    "https://assets.imgix.net/amsterdam.jpg";
   model.image_src = ImgixClient._buildURL(
     rawImageUrl,
     Object.assign({}, defaultParamsJSON, customImgixParams),

--- a/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.json
+++ b/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.json
@@ -7,7 +7,7 @@
       "id": "ImgixImage",
       "attribute_definitions": [
         {
-          "id": "image_url",
+          "id": "image_data",
           "name": "Target Image",
           "type": "custom",
           "required": true,


### PR DESCRIPTION
I updated this since the data that needs to be stored in the component data needs to be an object, so using `image_url` as the name didn't make much sense anymore