### PR TITLE
refactor: move event funcs outside of react app - EXAMPLE PR

### DIFF
--- a/frontend/src/components/SidebarApp.tsx
+++ b/frontend/src/components/SidebarApp.tsx
@@ -12,20 +12,10 @@ export function App() {
   let localization: any;
   let buttonEl: any;
 
-  subscribe(
-    "sfcc:ready",
-    async ({
-      value,
-      config,
-      isDisabled,
-      isRequired,
-      dataLocale,
-      displayLocale,
-    }: any) => {
-      // Extract `localization` data from `config`
-      ({ localization = {} } = config);
-    }
-  );
+  subscribe("sfcc:ready", async ({ config }: any) => {
+    // Extract `localization` data from `config`
+    ({ localization = {} } = config);
+  });
   function handleBreakoutApply(value: any) {
     emit({
       type: "sfcc:value",

--- a/frontend/src/components/SidebarApp.tsx
+++ b/frontend/src/components/SidebarApp.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
 import Imgix from "react-imgix";
 // TODO(luis): replace placeholder image
 import "../styles/App.css";
@@ -8,61 +8,61 @@ declare const emit: Function;
 declare const subscribe: Function;
 
 export function App() {
-    const [imgUrl, setImgUrl] = useState('-')
-    let localization: any;
-    let buttonEl: any;
+  const [imgUrl, setImgUrl] = useState("-");
+  let localization: any;
+  let buttonEl: any;
 
-    subscribe(
-        "sfcc:ready",
-        async ({
-                   value,
-                   config,
-                   isDisabled,
-                   isRequired,
-                   dataLocale,
-                   displayLocale,
-               }: any) => {
-            // Extract `localization` data from `config`
-            ({ localization = {} } = config);
-        }
+  subscribe(
+    "sfcc:ready",
+    async ({
+      value,
+      config,
+      isDisabled,
+      isRequired,
+      dataLocale,
+      displayLocale,
+    }: any) => {
+      // Extract `localization` data from `config`
+      ({ localization = {} } = config);
+    }
+  );
+  function handleBreakoutApply(value: any) {
+    emit({
+      type: "sfcc:value",
+      payload: value,
+    });
+  }
+
+  function handleBreakoutCancel(value: any) {
+    // Grab focus
+    console.log(value, " from cancel");
+    buttonEl && buttonEl.focus();
+  }
+
+  function handleBreakoutClose({ type, value }: any) {
+    setImgUrl(value.imgUrl);
+    // Now the "value" can be passed back to Page Designer
+    if (type === "sfcc:breakoutApply") {
+      handleBreakoutApply(value);
+    } else {
+      handleBreakoutCancel(value);
+    }
+  }
+
+  function handleBreakoutOpen() {
+    emit(
+      {
+        type: "sfcc:breakout",
+        payload: {
+          id: "imgixEditorBreakoutScript",
+          title: `${localization.titleBreakout}`,
+        },
+      },
+      handleBreakoutClose
     );
-    function handleBreakoutApply(value: any) {
-        emit({
-            type: "sfcc:value",
-            payload: value,
-        });
-    }
+  }
 
-    function handleBreakoutCancel(value: any) {
-        // Grab focus
-        console.log(value, ' from cancel')
-        buttonEl && buttonEl.focus();
-    }
-
-    function handleBreakoutClose({ type, value }: any) {
-        setImgUrl(value.imgUrl)
-        // Now the "value" can be passed back to Page Designer
-        if (type === "sfcc:breakoutApply") {
-            handleBreakoutApply(value);
-        } else {
-            handleBreakoutCancel(value);
-        }
-    }
-
-    function handleBreakoutOpen() {
-        emit(
-            {
-                type: "sfcc:breakout",
-                payload: {
-                    id: "imgixEditorBreakoutScript",
-                    title: `${localization.titleBreakout}`,
-                },
-            },
-            handleBreakoutClose
-        );
-    }
-
-    return (
+  return (
     <div className="App">
       <header className="App-header">
         <div>
@@ -72,7 +72,11 @@ export function App() {
               w: 350,
             }}
           />
-            <input id={'selectedImgUrl'} style={{ border: 'solid black 1px'}} value={imgUrl}/>
+          <input
+            id={"selectedImgUrl"}
+            style={{ border: "solid black 1px" }}
+            value={imgUrl}
+          />
           <AddImageIcon handleClick={handleBreakoutOpen} />
         </div>
       </header>


### PR DESCRIPTION
> EXAMPLE PR DO NOT MERGE

This is an example of how we could change #86 to get it working @syedbadshah-toptal. 

The main changes here are to 1) have the SFCC event handlers accept a callback, `cb` and 2) define them outside of the react application.

The first change allows us to pass a call to the state setting hook to the event handlers. The second change ensures the event handlers don't lose reference to the DOM when the React application re-renders.

_edit: I'm tired and can't English right now 😆 , but essentially the issue boils down to [binding the event handlers](https://www.freecodecamp.org/news/the-best-way-to-bind-event-handlers-in-react-282db2cf1530/) correctly. By doing it the way I've illustrated here we avoid the issue altogether, but ideally we wouldn't have to do all this callback nonsense_