### PR TITLE
PE-1579-1 refactor: memoise handle-breakout-open

### DIFF
--- a/frontend/src/components/SidebarApp.tsx
+++ b/frontend/src/components/SidebarApp.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
 import Imgix from "react-imgix";
 // TODO(luis): replace placeholder image
 import "../styles/App.css";
@@ -8,61 +8,68 @@ declare const emit: Function;
 declare const subscribe: Function;
 
 export function App() {
-    const [imgUrl, setImgUrl] = useState('-')
-    let localization: any;
-    let buttonEl: any;
+  const [imgUrl, setImgUrl] = useState("-");
+  let localization: any;
+  let buttonEl: any;
 
-    subscribe(
-        "sfcc:ready",
-        async ({
-                   value,
-                   config,
-                   isDisabled,
-                   isRequired,
-                   dataLocale,
-                   displayLocale,
-               }: any) => {
-            // Extract `localization` data from `config`
-            ({ localization = {} } = config);
-        }
+  subscribe(
+    "sfcc:ready",
+    async ({
+      value,
+      config,
+      isDisabled,
+      isRequired,
+      dataLocale,
+      displayLocale,
+    }: any) => {
+      // Extract `localization` data from `config`
+      ({ localization = {} } = config);
+    }
+  );
+  function handleBreakoutApply(value: any) {
+    emit({
+      type: "sfcc:value",
+      payload: value,
+    });
+  }
+
+  function handleBreakoutCancel(value: any) {
+    // Grab focus
+    console.log(value, " from cancel");
+    buttonEl && buttonEl.focus();
+  }
+
+  function handleBreakoutClose({ type, value }: any) {
+    setImgUrl(value.imgUrl);
+    // Now the "value" can be passed back to Page Designer
+    if (type === "sfcc:breakoutApply") {
+      handleBreakoutApply(value);
+    } else {
+      handleBreakoutCancel(value);
+    }
+  }
+
+  function handleBreakoutOpen() {
+    emit(
+      {
+        type: "sfcc:breakout",
+        payload: {
+          id: "imgixEditorBreakoutScript",
+          title: `${localization.titleBreakout}`,
+        },
+      },
+      handleBreakoutClose
     );
-    function handleBreakoutApply(value: any) {
-        emit({
-            type: "sfcc:value",
-            payload: value,
-        });
-    }
+  }
 
-    function handleBreakoutCancel(value: any) {
-        // Grab focus
-        console.log(value, ' from cancel')
-        buttonEl && buttonEl.focus();
-    }
+  const memoizedHandleBreakoutOpen = React.useCallback(
+    () => {
+      handleBreakoutOpen();
+    },
+    [] // Tells React to memoize regardless of arguments.
+  );
 
-    function handleBreakoutClose({ type, value }: any) {
-        setImgUrl(value.imgUrl)
-        // Now the "value" can be passed back to Page Designer
-        if (type === "sfcc:breakoutApply") {
-            handleBreakoutApply(value);
-        } else {
-            handleBreakoutCancel(value);
-        }
-    }
-
-    function handleBreakoutOpen() {
-        emit(
-            {
-                type: "sfcc:breakout",
-                payload: {
-                    id: "imgixEditorBreakoutScript",
-                    title: `${localization.titleBreakout}`,
-                },
-            },
-            handleBreakoutClose
-        );
-    }
-
-    return (
+  return (
     <div className="App">
       <header className="App-header">
         <div>
@@ -72,8 +79,12 @@ export function App() {
               w: 350,
             }}
           />
-            <input id={'selectedImgUrl'} style={{ border: 'solid black 1px'}} value={imgUrl}/>
-          <AddImageIcon handleClick={handleBreakoutOpen} />
+          <input
+            id={"selectedImgUrl"}
+            style={{ border: "solid black 1px" }}
+            value={imgUrl}
+          />
+          <AddImageIcon handleClick={memoizedHandleBreakoutOpen} />
         </div>
       </header>
     </div>


### PR DESCRIPTION
This commit uses `React.useCallback` to memoise `handleBreakoutOpen()`. This ensures the ref. to the function is not lost on `App` rerenders, since the function will never change since it has no inputs to watch changes for.

<!---GHSTACKOPEN-->
### Stacked PR Chain: PE-1579-1
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#86|PE-1579-1 Trigger imgix modal|Pending|-|
|#88|👉 PE-1579-1 refactor: memoise handle-breakout-open|Pending|#86|
|#89|PE-1579-1 feat: show selected image in sidebar|Pending|#88|

<!---GHSTACKCLOSE-->

