### PR TITLE
PE-1597 feat: automatically select source on first render

### DIFF
--- a/frontend/src/components/AssetBrowser/AssetBrowser.tsx
+++ b/frontend/src/components/AssetBrowser/AssetBrowser.tsx
@@ -118,7 +118,11 @@ export function AssetBrowser({
   return (
     <div className="ix-asset-browser">
       <div className="ix-asset-title-bar-container">
-        <SourceSelect sources={sources} handleSelect={handleSourceSelect} />
+        <SourceSelect
+          sources={sources}
+          selectedSource={selectedSource}
+          handleSelect={handleSourceSelect}
+        />
         <SearchBar handleSubmit={handleSearch} />
       </div>
       <AssetGrid

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
@@ -8,20 +8,32 @@ import "../../../styles/SourceSelect.css";
 
 interface Props {
   sources: ImgixGETSourcesData;
+  selectedSource: ImgixGETSourcesData[0] | null;
   handleSelect: (sourceId: string) => void;
 }
 
-export function SourceSelect({ sources, handleSelect }: Props): ReactElement {
-  const [selectedSourceId, setSelectedSourceId] = React.useState("");
+export function SourceSelect({
+  sources,
+  selectedSource,
+  handleSelect,
+}: Props): ReactElement {
   const [isOpen, setIsOpen] = React.useState(false);
-  const selectedSource = sources.find(
-    (source) => source.id === selectedSourceId
-  );
+
+  const updateSource = (sourceId: string) => {
+    setIsOpen(false);
+    handleSelect(sourceId);
+  };
 
   React.useEffect(() => {
     if (sources.length) {
-      setSelectedSourceId(sources[0].id);
-      handleSelect(sources[0].id);
+      // if selectedSourceId is not set or no longer in the sources array,
+      // set the selectedSourceId to the first source
+      if (
+        !selectedSource ||
+        !sources.map((source) => source.id).includes(selectedSource.id)
+      ) {
+        updateSource(sources[0].id);
+      }
     }
   }, [sources]);
 
@@ -30,19 +42,12 @@ export function SourceSelect({ sources, handleSelect }: Props): ReactElement {
       <li
         key={source.id}
         value={source.id}
-        onClick={(e) => handleClick(source.id)}
+        onClick={() => updateSource(source.id)}
       >
         <Button label={source.attributes.name} Icon={<SourceMenuSvg />} />
       </li>
     );
   });
-
-  // create on click handler that closes the dropdown and sets the selected source
-  const handleClick = (id: string) => {
-    setIsOpen(!isOpen);
-    setSelectedSourceId(id);
-    handleSelect(id);
-  };
 
   const noSourcePlaceholder = (
     <li key="no-source" value="">

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
@@ -18,6 +18,12 @@ export function SourceSelect({ sources, handleSelect }: Props): ReactElement {
     (source) => source.id === selectedSourceId
   );
 
+  React.useEffect(() => {
+    if (sources.length) {
+      setSelectedSourceId(sources[0].id);
+    }
+  }, [sources]);
+
   const sourceList = sources.map((source) => {
     return (
       <li

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
@@ -35,7 +35,7 @@ export function SourceSelect({
         updateSource(sources[0].id);
       }
     }
-  }, [sources]);
+  }, [sources]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const sourceList = sources.map((source) => {
     return (

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
@@ -21,6 +21,7 @@ export function SourceSelect({ sources, handleSelect }: Props): ReactElement {
   React.useEffect(() => {
     if (sources.length) {
       setSelectedSourceId(sources[0].id);
+      handleSelect(sources[0].id);
     }
   }, [sources]);
 

--- a/frontend/src/components/grids/AssetGrid.tsx
+++ b/frontend/src/components/grids/AssetGrid.tsx
@@ -27,19 +27,23 @@ export function AssetGrid({
   handleAssetGridClick,
 }: Props): ReactElement {
   // create grid-items
+  const [selectedAssetId, setSelectedAssetId] = React.useState<string>("");
+  const onClick = (asset: ImgixGETAssetsData[0]) => {
+    setSelectedAssetId(asset.id);
+    if (handleAssetGridClick) {
+      handleAssetGridClick({ src: asset });
+    }
+  };
   const gridItems = assets.map((asset, idx) => {
     return (
-      <div className="ix-grid-item" key={`${asset.id}-${idx}`}>
-        <div
-          className="ix-grid-item-image"
-          onClick={() => {
-            if (handleAssetGridClick) {
-              handleAssetGridClick({
-                src: asset,
-              });
-            }
-          }}
-        >
+      <div
+        className={`ix-grid-item ${
+          selectedAssetId === asset.id ? "ix-grid-item-selected" : ""
+        }`}
+        key={`${asset.id}-${idx}`}
+        onClick={() => onClick(asset)}
+      >
+        <div className="ix-grid-item-image">
           <Imgix
             src={"https://" + domain + asset.attributes.origin_path}
             imgixParams={{

--- a/frontend/src/stories/SourceSelect.tsx
+++ b/frontend/src/stories/SourceSelect.tsx
@@ -9,10 +9,22 @@ interface Props {
 }
 
 export function SourceSelect({ sources }: Props): ReactElement {
-  const handleSelect = (source: string) => {};
+  const [selectedSource, setSelectedSource] = React.useState(sources[0]);
+  const handleSourceSelect = (sourceId: string) => {
+    // store the selected source and fetch its assets
+    const source = sources.find(
+      (currentSource: ImgixGETSourcesData[0]) => currentSource.id === sourceId
+    );
+    if (!source) return;
+    setSelectedSource(source);
+  };
   return (
     <div className="button-story-layout">
-      <_SourceSelect handleSelect={handleSelect} sources={sources} />
+      <_SourceSelect
+        handleSelect={handleSourceSelect}
+        selectedSource={selectedSource}
+        sources={sources}
+      />
     </div>
   );
 }

--- a/frontend/src/styles/Form.css
+++ b/frontend/src/styles/Form.css
@@ -2,7 +2,7 @@
 @media (min-width: 694px) {
   .ix-asset-simple-search-content {
     visibility: visible;
-    position: absolute;
+    position: relative;
     top: 0;
     right: 0;
     bottom: auto;

--- a/frontend/src/styles/Grid.css
+++ b/frontend/src/styles/Grid.css
@@ -42,10 +42,19 @@
   max-height: 340px;
   max-width: 340px;
   grid-column: span 2;
+  border-radius: 4px;
 }
 
 .ix-grid-item:hover {
-  box-shadow: 0 0 0 2px rgb(0 191 254 / 40%);
+  box-shadow: 0 0 0 2px rgba(0, 191, 254, 0.4);
+}
+
+.ix-grid-item-selected {
+  box-shadow: 0 0 0 2px #00bffe;
+}
+
+.ix-grid-item-selected:hover {
+  box-shadow: 0 0 0 2px #00bffe;
 }
 
 .ix-grid-item-image {


### PR DESCRIPTION
> Stacks onto #93. Will rebase on `next` once that entire stack is merged in.

## Before
On first render, a user had to select a source before any assets were requested

## After
The first `sources` In `sources:[]` is set as a "default" source, and its assets are requested on the first render.

### Notable changes
This PR automatically sets the `selectedSourceId` to be `sources[0].id` on the `SourceSelect.tsx` first render. This way, the user is always greeted with a pre-selected source. It then invokes `handleSelect()` on the first render if `sources.length`, ensuring we request the automatically set "default" source's assets on the AssetGrid's first render.

Finally, the PR removes the `position: absolute` attribute from the `Form.css` file for `.ix-asset-simple-search-content`. This fixes an issue where the source select dropdown was not visible at certain screen sizes.

In a future PR, we should more intelligently set a "default" source rather than defaulting to the first source.

