### PR TITLE
PE-1584 feat: style image on select

### DIFF
--- a/frontend/src/components/grids/AssetGrid.tsx
+++ b/frontend/src/components/grids/AssetGrid.tsx
@@ -27,19 +27,23 @@ export function AssetGrid({
   handleAssetGridClick,
 }: Props): ReactElement {
   // create grid-items
+  const [selectedAssetId, setSelectedAssetId] = React.useState<string>("");
+  const onClick = (asset: ImgixGETAssetsData[0]) => {
+    setSelectedAssetId(asset.id);
+    if (handleAssetGridClick) {
+      handleAssetGridClick({ src: asset });
+    }
+  };
   const gridItems = assets.map((asset, idx) => {
     return (
-      <div className="ix-grid-item" key={`${asset.id}-${idx}`}>
-        <div
-          className="ix-grid-item-image"
-          onClick={() => {
-            if (handleAssetGridClick) {
-              handleAssetGridClick({
-                src: asset,
-              });
-            }
-          }}
-        >
+      <div
+        className={`ix-grid-item ${
+          selectedAssetId === asset.id ? "ix-grid-item-selected" : ""
+        }`}
+        key={`${asset.id}-${idx}`}
+        onClick={() => onClick(asset)}
+      >
+        <div className="ix-grid-item-image">
           <Imgix
             src={"https://" + domain + asset.attributes.origin_path}
             imgixParams={{

--- a/frontend/src/styles/Grid.css
+++ b/frontend/src/styles/Grid.css
@@ -42,10 +42,19 @@
   max-height: 340px;
   max-width: 340px;
   grid-column: span 2;
+  border-radius: 4px;
 }
 
 .ix-grid-item:hover {
-  box-shadow: 0 0 0 2px rgb(0 191 254 / 40%);
+  box-shadow: 0 0 0 2px rgba(0, 191, 254, 0.4);
+}
+
+.ix-grid-item-selected {
+  box-shadow: 0 0 0 2px #00bffe;
+}
+
+.ix-grid-item-selected:hover {
+  box-shadow: 0 0 0 2px #00bffe;
 }
 
 .ix-grid-item-image {


### PR DESCRIPTION
> Stacks on top of #93. Will rebase on `next` once that stack is merged in.

## Before
An image had to be clicked for it to be selected. No styling changes reflected which image in the gallery had to be selected.

## After
Any part of the asset, ie the filename, for example, can be clicked for it to be selected. A drop-shadow is added to the selected asset.

### Notable changes
This commit styles the selected `AssetGrid` "card" when clicked. the `onCLick` handler was moved to the parent div to account for when a user clicks on the file name. Previously, a user had to click on the actual image for the selection to register.

The styling is applied to the "card" by conditionally adding a class to the container div. This is done by creating a component state that changes the selected `asset.id` whenever a "card" is clicked. If the seleceted ID and the card ID match, the style is applied to that card's container.

## Video 📹 

https://user-images.githubusercontent.com/16711614/142072179-7ef10db3-2be7-4310-82bb-5adf8c28393a.mov


