### PR TITLE
chore: update asset grid to design guide styling

### DIFF
--- a/frontend/src/components/grids/AssetGrid.tsx
+++ b/frontend/src/components/grids/AssetGrid.tsx
@@ -47,8 +47,21 @@ export function AssetGrid({
               fit: "crop",
               crop: "entropy",
             }}
-            // TODO: ensure sizes is set correctly
-            sizes="(min-width: 480px) calc(12.5vw - 20px)"
+            /* This sizes attribute is a monster and sets the size of the image
+             * correctly, handling both the SF breakpoints and the design
+             * breakpoints
+             * The SF modal has a breakpoint at 768px (48rem), below which the
+             * modal has a margin around it of 32px, and above which it has a
+             * margin of 5% each side.
+             * In these calculates, the format is:
+             * calc((100vw - SFmargin - modalMargin - betweenColumnMarginSum)/numColumns)
+             * */
+            sizes="(max-width: 500px) calc((100vw - 64px - 32px - 16px)/2),
+            (max-width: 700px) calc((100vw - 64px - 32px - 32px)/3),
+            (max-width: 768px) calc((100vw - 64px - 32px - 48px)/4),
+            (max-width: 820px) calc((100vw - 10vw - 32px - 48px)/4),
+            (max-width: 960px) calc((100vw - 10vw - 32px - 80px)/6),
+            calc((100vw - 10vw - 32px - 96px)/7)"
           />
         </div>
         <p className="ix-grid-item-filename">

--- a/frontend/src/components/grids/AssetGrid.tsx
+++ b/frontend/src/components/grids/AssetGrid.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement } from "react";
 import Imgix from "react-imgix";
+import "../../styles/Grid.css";
 import { ImgixGETAssetsData } from "../../types";
 import { LoadingSpinner } from "../LoadingSpinner";
-import "../../styles/Grid.css";
 
 export type IAssetGridClickCallback = (data: {
   src: ImgixGETAssetsData[0];
@@ -42,13 +42,12 @@ export function AssetGrid({
         >
           <Imgix
             src={"https://" + domain + asset.attributes.origin_path}
-            width={340}
-            height={340}
             imgixParams={{
               auto: "format",
               fit: "crop",
               crop: "entropy",
             }}
+            // TODO: ensure sizes is set correctly
             sizes="(min-width: 480px) calc(12.5vw - 20px)"
           />
         </div>

--- a/frontend/src/stories/AssetGrid.stories.tsx
+++ b/frontend/src/stories/AssetGrid.stories.tsx
@@ -1,5 +1,6 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { ImgixGETAssetsData } from "../types/imgixAPITypes";
 import { AssetGrid } from "./AssetGrid";
 
 export default {
@@ -14,36 +15,12 @@ const Template: ComponentStory<typeof AssetGrid> = (args) => (
 export const BasicGrid = Template.bind({});
 BasicGrid.args = {
   domain: "sdk-test.imgix.net",
-  assets: [
-    {
-      attributes: {
-        origin_path: "/amsterdam.jpg",
-      },
-    } as any,
-    {
-      attributes: {
-        origin_path: "/amsterdam.jpg",
-      },
-    } as any,
-    {
-      attributes: {
-        origin_path: "/amsterdam.jpg",
-      },
-    } as any,
-    {
-      attributes: {
-        origin_path: "/amsterdam.jpg",
-      },
-    } as any,
-    {
-      attributes: {
-        origin_path: "/amsterdam.jpg",
-      },
-    } as any,
-    {
-      attributes: {
-        origin_path: "/amsterdam.jpg",
-      },
-    } as any,
-  ] as any,
+  assets: Array.from({ length: 10 + Math.floor(Math.random() * 50) }).map(
+    (v) =>
+      ({
+        attributes: {
+          origin_path: "/amsterdam.jpg",
+        },
+      } as ImgixGETAssetsData[0])
+  ),
 };

--- a/frontend/src/stories/AssetGrid.tsx
+++ b/frontend/src/stories/AssetGrid.tsx
@@ -2,8 +2,9 @@ import React, { ReactElement } from "react";
 import { AssetGrid as _AssetGrid } from "../components/grids/AssetGrid";
 import "../styles/App.css";
 import "../styles/Grid.css";
+import { ImgixGETAssetsData } from "../types";
 interface Props {
-  assets: [];
+  assets: ImgixGETAssetsData;
   domain: string;
 }
 

--- a/frontend/src/styles/Grid.css
+++ b/frontend/src/styles/Grid.css
@@ -61,13 +61,18 @@
   justify-content: flex-end;
   flex: 0 1 auto;
   font-size: 14px;
-  line-height: 20px;
+  line-height: 32px;
   color: #6c7f8e;
-  font-weight: 400;
+  font-style: normal;
+  font-weight: normal;
+  /* This supports the "ellipsis" behaviour to ensure that the filename stays on
+   * one line */
   white-space: nowrap;
   position: relative;
   padding: 6px 10px;
   margin: 0px;
+
+  text-align: center;
 }
 
 .ix-grid-item-filename:before {

--- a/frontend/src/styles/Grid.css
+++ b/frontend/src/styles/Grid.css
@@ -8,10 +8,10 @@
 .ix-grid {
   padding: 15px;
   display: grid;
-  grid-gap: 20px;
+  grid-gap: 16px;
   justify-items: stretch;
   align-items: start;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(14, 1fr);
 }
 @media (max-width: 900px) {
   .ix-grid {
@@ -37,6 +37,7 @@
   overflow: hidden;
   max-height: 340px;
   max-width: 340px;
+  grid-column: span 2;
 }
 
 .ix-grid-item:hover {

--- a/frontend/src/styles/Grid.css
+++ b/frontend/src/styles/Grid.css
@@ -46,14 +46,14 @@
 .ix-grid-item-image {
   position: relative;
   overflow: hidden;
-  padding-bottom: 80%;
+  height: 180px;
 }
+
 .ix-grid-item-image img {
   display: block;
-  position: absolute;
-  top: 0;
-  left: 0;
+  object-fit: cover;
   width: 100%;
+  height: 100%;
 }
 
 .ix-grid-item-filename {

--- a/frontend/src/styles/Grid.css
+++ b/frontend/src/styles/Grid.css
@@ -2,7 +2,7 @@
   min-height: 100%;
   padding: 32px 16px;
   box-sizing: border-box;
-  background-color: #e3e7eb;
+  background-color: #eef0f2;
 }
 
 .ix-grid {

--- a/frontend/src/styles/Grid.css
+++ b/frontend/src/styles/Grid.css
@@ -1,12 +1,11 @@
 .ix-grid-container {
   min-height: 100%;
-  padding: 12px 20px;
+  padding: 32px 16px;
   box-sizing: border-box;
   background-color: #e3e7eb;
 }
 
 .ix-grid {
-  padding: 15px;
   display: grid;
   grid-gap: 16px;
   justify-items: stretch;

--- a/frontend/src/styles/Grid.css
+++ b/frontend/src/styles/Grid.css
@@ -12,20 +12,25 @@
   align-items: start;
   grid-template-columns: repeat(14, 1fr);
 }
-@media (max-width: 900px) {
+@media (max-width: 960px) {
   .ix-grid {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(12, 1fr);
   }
 }
 
-@media (max-width: 694px) {
+@media (max-width: 820px) {
   .ix-grid {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(8, 1fr);
   }
 }
-@media (max-width: 540px) {
+@media (max-width: 700px) {
   .ix-grid {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(6, 1fr);
+  }
+}
+@media (max-width: 500px) {
+  .ix-grid {
+    grid-template-columns: repeat(4, 1fr);
   }
 }
 


### PR DESCRIPTION
This PR updates the asset grid styling, bringing it up to standard with the style guide. Things that were changed included: font sizing, image sizing, column padding and margin, colours, and background colours.

![image](https://user-images.githubusercontent.com/615334/142268056-a717bdaf-cb02-4d30-acf9-795c82870c11.png)
