### PR TITLE
feat: limit generated srcsets to image width  [f-5]

### DIFF
--- a/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
+++ b/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
@@ -38,6 +38,8 @@ module.exports.render = function (context, modelIn) {
 
   const ixlib = "sfccPD-" + version.version;
 
+  const mediaWidth = content.image_data.mediaWidth;
+
   // use to give link on the image, if we click on image it take to us to that page.
   model.link = content.imageLink ? content.imageLink : "#";
   model.alt = content.alt ? content.alt : null;
@@ -58,10 +60,13 @@ module.exports.render = function (context, modelIn) {
   model.image_srcset = ImgixClient._buildSrcSet(
     rawImageUrl,
     Object.assign({}, defaultParamsJSON, customImgixParams),
-    {
-      includeLibraryParam: false,
-      libraryParam: ixlib,
-    }
+    Object.assign(
+      {
+        includeLibraryParam: false,
+        libraryParam: ixlib,
+      },
+      mediaWidth && { maxWidth: mediaWidth }
+    )
   );
   if (!fixedSize) {
     model.image_sizes = content.sizes;

--- a/frontend/src/components/AssetBrowser/AssetBrowserContainer.tsx
+++ b/frontend/src/components/AssetBrowser/AssetBrowserContainer.tsx
@@ -218,6 +218,8 @@ export class AssetBrowserContainer extends Component<Props, State> {
 
     const data = {
       src,
+      mediaWidth: assetData.attributes.media_width,
+      mediaHeight: assetData.attributes.media_height,
     };
 
     this.props.onSelectAsset(data);

--- a/frontend/src/index-breakout.tsx
+++ b/frontend/src/index-breakout.tsx
@@ -28,14 +28,22 @@ export const createBreakoutApp = () => {
     rootEditorElement.innerHTML = `<h3>Breakout: should be replaced by React</h3>`;
     document.body.appendChild(rootEditorElement);
 
-    var handleSelect: IBreakoutAppOnSubmit = function handleSelect({ src }) {
+    var handleSelect: IBreakoutAppOnSubmit = function handleSelect({
+      src,
+      mediaWidth,
+      mediaHeight,
+    }) {
       // The value changed and the breakout editor's host is informed about the
       // value update via a `sfcc:value` event.
 
       if (!src) {
         return;
       }
-      const payload: IImgixCustomAttributeValue = { src };
+      const payload: IImgixCustomAttributeValue = {
+        src,
+        mediaWidth,
+        mediaHeight,
+      };
       emit({
         type: "sfcc:value",
         payload,

--- a/frontend/src/services/imgixAPIService.ts
+++ b/frontend/src/services/imgixAPIService.ts
@@ -71,7 +71,7 @@ export const imgixAPI = {
       ) {
         // ?page[number]=${n}&page[size]=18`
         return await makeRequest<ImgixGETAssetsData>({
-          url: `assets/${sourceId}?page[cursor]=${index}&page[limit]=${size}&sort=date_created&fields[assets]=name,description,origin_path`,
+          url: `assets/${sourceId}?page[cursor]=${index}&page[limit]=${size}&sort=date_created&fields[assets]=name,description,origin_path,media_height,media_width`,
           apiKey,
         });
       },

--- a/frontend/src/types/breakoutAppPublic.ts
+++ b/frontend/src/types/breakoutAppPublic.ts
@@ -1,1 +1,5 @@
-export type IBreakoutAppOnSubmit = (data: { src: string }) => void;
+export type IBreakoutAppOnSubmit = (data: {
+  src: string;
+  mediaWidth: number;
+  mediaHeight: number;
+}) => void;

--- a/frontend/src/types/imgixAPITypes.ts
+++ b/frontend/src/types/imgixAPITypes.ts
@@ -12,6 +12,8 @@ export type ImgixGETAssetsData = {
     description: null | string;
     name: null | string;
     origin_path: string;
+    media_height: number;
+    media_width: number;
   };
   id: string;
   type: "assets";

--- a/frontend/src/types/imgixSF.ts
+++ b/frontend/src/types/imgixSF.ts
@@ -1,1 +1,5 @@
-export type IImgixCustomAttributeValue = { src: string };
+export type IImgixCustomAttributeValue = {
+  src: string;
+  mediaWidth: number;
+  mediaHeight: number;
+};


### PR DESCRIPTION
Before this PR rendered images had a srcset that included widths that would be too big for the image, resulting in wasted bandwidth (both for the image and the page size):

![image](https://user-images.githubusercontent.com/615334/142408549-51044b23-bdbb-4327-be68-e16f6bbb8d2c.png)

After this PR, the srcset widths are limited by the images' native resolutions:

![image](https://user-images.githubusercontent.com/615334/142408603-5bf386e9-56ab-40ee-be35-2348ba36e7e7.png)

Showing the data being passed around:
![image](https://user-images.githubusercontent.com/615334/142408610-07e52fca-d447-4775-8a72-75b1e8edaf21.png)






<!---GHSTACKOPEN-->
### Stacked PR Chain: f-5
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#102|👉 feat: limit generated srcsets to image width  |Pending|-|
|#106|chore: refactor asset click handling to AssetBrowser |Pending|#102|
|#104|chore: reduce number of files in sidebar app story |**Approved**|#106|
|#105|fix: render image in sidebar app at right size |**Approved**|#104|
|#107|chore: add "add image" button to empty state |**Approved**|#105|
|#108|feat: add replace image button overlay |**Approved**|#107|
|#109|chore: change image preview aspect raio in sidebar to be golden ratio |**Approved**|#108|
|#110|chore: add user-select: none to button text to stop highlighting |Pending|#109|

<!---GHSTACKCLOSE-->




