### PR TITLE
chore: update linking logic

### DIFF
--- a/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
+++ b/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
@@ -44,7 +44,7 @@ module.exports.render = function (context, modelIn) {
 
   // use to give link on the image, if we click on image it take to us to that page.
   model.alt = content.alt ? content.alt : null;
-  model.anchorTagUrl = content.anchorTagUrl ? content.anchorTagUrl : "#";
+  model.anchorTagUrl = content.anchorTagUrl ? content.anchorTagUrl : "";
 
   const rawImageUrl = content.image_data && content.image_data.src;
 

--- a/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
+++ b/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
@@ -43,7 +43,6 @@ module.exports.render = function (context, modelIn) {
   const mediaWidth = content.image_data.mediaWidth;
 
   // use to give link on the image, if we click on image it take to us to that page.
-  model.link = content.imageLink ? content.imageLink : "#";
   model.alt = content.alt ? content.alt : null;
   model.anchorTagUrl = content.anchorTagUrl ? content.anchorTagUrl : "#";
 

--- a/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.json
+++ b/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.json
@@ -20,8 +20,8 @@
         },
         {
           "id": "anchorTagUrl",
-          "name": "Anchor Tag URL",
-          "description": "This link will passed to the isml template from where this image will be wrapped in a anchor tag",
+          "name": "URL to Link To",
+          "description": "If this value is set, clicking on the image will redirect the user to this page.",
           "type": "string",
           "required": false
         },

--- a/cartridges/int_imgix_pd/cartridge/templates/default/experience/components/imgix/imageComponent.isml
+++ b/cartridges/int_imgix_pd/cartridge/templates/default/experience/components/imgix/imageComponent.isml
@@ -2,14 +2,14 @@
   <isif condition="${pdict && pdict.image_src}">
     <isset name="noText" value="No text" scope="page" />
     <isprint value="${pdict.title}" />
-    <isif condition="${pdict.anchorTagUrl == '#'}">
-      <img src="${pdict.image_src}" srcset="${pdict.image_srcset}" sizes="${pdict.image_sizes}"
-        alt="${pdict.alt ? pdict.alt : noText}" />
+    <isif condition="${!empty(pdict.anchorTagUrl)}">
+      <a href="${pdict.anchorTagUrl}" aria-label="${pdict.alt ? pdict.alt : 'no alt text'}">
+        <img src="${pdict.image_src}" srcset="${pdict.image_srcset}" sizes="${pdict.image_sizes}"
+          alt="${pdict.alt ? pdict.alt : noText}" />
+      </a>
       <iselse>
-        <a href="${pdict.anchorTagUrl}" aria-label="${pdict.alt ? pdict.alt : 'no alt text'}">
-          <img src="${pdict.image_src}" srcset="${pdict.image_srcset}" sizes="${pdict.image_sizes}"
-            alt="${pdict.alt ? pdict.alt : noText}" />
-        </a>
+        <img src="${pdict.image_src}" srcset="${pdict.image_srcset}" sizes="${pdict.image_sizes}"
+          alt="${pdict.alt ? pdict.alt : noText}" />
     </isif>
 <iselse/>
     <div style="display: flex; flex-direction: column; align-items: center;">


### PR DESCRIPTION
Before this PR, the logic would use `#` as the empty state. I updated this to use an empty string, which is more error-safe. This PR also updates the description of the attribute.