### PR TITLE
chore: fix className overriding [f-7]

### DIFF
--- a/frontend/src/common/hooks/useListSelectionBehavior.tsx
+++ b/frontend/src/common/hooks/useListSelectionBehavior.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+
+export const useListSelectionBehavior = <Item,>({
+  /**
+   * Used to disable this behavior for UI items that are only visible
+   * occasionally, e.g. dropdowns
+   */
+  active = true,
+  /**
+   * The items to navigate through
+   */
+  items,
+  /**
+   * Will be called when the current item should be confirmed, e.g. after an Enter key press
+   */
+  onSelectCurrentItem,
+}: {
+  active?: boolean;
+  items: Item[];
+  onSelectCurrentItem?: (item: Item) => void;
+}) => {
+  // Keep state reference to last item selected by cursor and mouse
+  const [selectedItemUnsafe, setSelectedItem] = useState<Item | undefined>(
+    undefined
+  );
+
+
+  const getIndexCurrentItem = () =>
+    selectedItemUnsafe ? items.indexOf(selectedItemUnsafe) : -1;
+
+  const setNextItem = () => {
+    if (items.length === 0) {
+      return;
+    }
+    const currentIndex = getIndexCurrentItem();
+    const atEndOfList = currentIndex === items.length - 1;
+    if (currentIndex === -1) {
+      setSelectedItem(items[0]);
+    } else if (!atEndOfList) {
+      setSelectedItem(items[currentIndex + 1]);
+    }
+  };
+  const setPrevItem = () => {
+    if (items.length === 0) {
+      return;
+    }
+    const currentIndex = getIndexCurrentItem();
+    const atBeginningOfList = currentIndex === 0;
+    if (currentIndex === -1) {
+      setSelectedItem(items[items.length - 1]);
+    } else if (!atBeginningOfList) {
+      setSelectedItem(items[currentIndex - 1]);
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    switch (event.code) {
+      case "ArrowDown":
+      case "j":
+        setNextItem();
+        event.preventDefault();
+        break;
+      case "ArrowUp":
+      case "k":
+        setPrevItem();
+        event.preventDefault();
+        break;
+      case "Enter":
+        onSelectCurrentItem &&
+          selectedItemUnsafe &&
+          onSelectCurrentItem(selectedItemUnsafe);
+        break;
+    }
+  };
+
+  // Handle mouse interactions up and down to select items
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, true);
+    };
+  });
+
+  const currentSelected =
+    selectedItemUnsafe && items.includes(selectedItemUnsafe)
+      ? selectedItemUnsafe
+      : undefined;
+
+
+  const handleOtherInteraction = (item: Item | undefined) => {
+    setSelectedItem(item);
+  };
+
+  return {
+    /**
+     * The currently selected item
+     */
+    currentSelected,
+    /**
+     * Should be called if another item should be highlighted/selected from another UI interaction, e.g. a mouse hover
+     */
+    handleOtherInteraction,
+  };
+};

--- a/frontend/src/common/hooks/useListSelectionBehavior.tsx
+++ b/frontend/src/common/hooks/useListSelectionBehavior.tsx
@@ -73,7 +73,7 @@ export const useListSelectionBehavior = <Item,>({
     }
   };
 
-  // Handle mouse interactions up and down to select items
+  // Handle keyboard interactions up and down to select items
   useEffect(() => {
     document.addEventListener("keydown", handleKeyDown, true);
     return () => {

--- a/frontend/src/common/hooks/useListSelectionBehavior.tsx
+++ b/frontend/src/common/hooks/useListSelectionBehavior.tsx
@@ -24,7 +24,6 @@ export const useListSelectionBehavior = <Item,>({
     undefined
   );
 
-
   const getIndexCurrentItem = () =>
     selectedItemUnsafe ? items.indexOf(selectedItemUnsafe) : -1;
 
@@ -66,7 +65,8 @@ export const useListSelectionBehavior = <Item,>({
         event.preventDefault();
         break;
       case "Enter":
-        onSelectCurrentItem &&
+        active &&
+          onSelectCurrentItem &&
           selectedItemUnsafe &&
           onSelectCurrentItem(selectedItemUnsafe);
         break;
@@ -85,7 +85,6 @@ export const useListSelectionBehavior = <Item,>({
     selectedItemUnsafe && items.includes(selectedItemUnsafe)
       ? selectedItemUnsafe
       : undefined;
-
 
   const handleOtherInteraction = (item: Item | undefined) => {
     setSelectedItem(item);

--- a/frontend/src/components/AssetBrowser/AssetBrowser.module.scss
+++ b/frontend/src/components/AssetBrowser/AssetBrowser.module.scss
@@ -11,7 +11,12 @@
 }
 .sourceSelect {
   width: 228px;
+  flex: 0 1 auto;
 }
 .assetGridContainer {
   padding: 32px 16px;
+}
+
+.spacer {
+  flex: 0 0 8px;
 }

--- a/frontend/src/components/AssetBrowser/AssetBrowser.tsx
+++ b/frontend/src/components/AssetBrowser/AssetBrowser.tsx
@@ -106,7 +106,7 @@ export function AssetBrowser({
     // If the source has no custom domains, return the source name as the domain
     if (!source || !source.attributes) return "";
 
-    const customDomains = source?.attributes?.custom_domains;
+    const customDomains = source?.attributes?.deployment.custom_domains;
     if (!customDomains || !customDomains.length) {
       return source.attributes.name + ".imgix.net";
     }

--- a/frontend/src/components/AssetBrowser/AssetBrowser.tsx
+++ b/frontend/src/components/AssetBrowser/AssetBrowser.tsx
@@ -148,6 +148,7 @@ export function AssetBrowser({
           handleSelect={handleSourceSelect}
           className={styles.sourceSelect}
         />
+        <div className={styles.spacer} />
         <SearchBar handleSubmit={handleSearch} />
       </div>
       <div className={styles.assetGridContainer}>

--- a/frontend/src/components/buttons/Button.module.scss
+++ b/frontend/src/components/buttons/Button.module.scss
@@ -7,7 +7,6 @@
   border-radius: 4px;
   background: #fff;
   color: #475f72;
-  width: 100%;
 
   &:hover {
     background-color: #e8f0f4;

--- a/frontend/src/components/buttons/Button.module.scss
+++ b/frontend/src/components/buttons/Button.module.scss
@@ -23,7 +23,7 @@
   }
 }
 
-.icon {
+.leftIcon {
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
@@ -41,7 +41,7 @@
   text-overflow: ellipsis;
 }
 
-.rightIconButton {
+.rightIcon {
   flex: 0 0 auto;
   margin-left: 10px;
   width: 26px;

--- a/frontend/src/components/buttons/Button.tsx
+++ b/frontend/src/components/buttons/Button.tsx
@@ -9,7 +9,7 @@ interface Props {
   rightIconClassName?: string;
   className?: string;
   flat?: boolean;
-  onClick?: () => void;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
 }
 export const Button = ({
   label,

--- a/frontend/src/components/buttons/Button.tsx
+++ b/frontend/src/components/buttons/Button.tsx
@@ -1,36 +1,26 @@
 import React from "react";
-import { DownArrowSvg } from "../icons/DownArrowSvg";
 import styles from "./Button.module.scss";
 
 interface Props {
   label: string;
-  type?: "dropdown" | null;
-  Icon?: React.ReactElement;
-  onClick?: () => void;
-  flat?: boolean;
+  leftIcon?: React.ReactElement;
+  leftIconClassName?: string;
+  rightIcon?: React.ReactElement;
+  rightIconClassName?: string;
   className?: string;
-  rightButtonClassName?: string;
+  flat?: boolean;
+  onClick?: () => void;
 }
 export const Button = ({
-  type,
   label,
   onClick,
-  Icon,
+  leftIcon,
+  rightIcon,
   flat,
   className,
-  rightButtonClassName,
+  rightIconClassName,
+  leftIconClassName,
 }: Props) => {
-  let _type;
-
-  // in future we can add more types
-  switch (type) {
-    case "dropdown":
-      _type = <DownArrowSvg />;
-      break;
-
-    default:
-      break;
-  }
   return (
     <div
       onClick={onClick}
@@ -40,17 +30,27 @@ export const Button = ({
         (className ? ` ${className}` : "")
       }
     >
-      <div className={styles.icon}>{Icon}</div>
+      {leftIcon && (
+        <div
+          className={
+            styles.leftIcon + (leftIconClassName ? ` ${leftIconClassName}` : "")
+          }
+        >
+          {leftIcon}
+        </div>
+      )}
       <div className={styles.label}>{label}</div>
       <div className={styles.spacer}></div>
-      <div
-        className={
-          styles.rightIconButton +
-          (rightButtonClassName ? ` ${rightButtonClassName}` : "")
-        }
-      >
-        {_type}
-      </div>
+      {rightIcon && (
+        <div
+          className={
+            styles.rightIcon +
+            (rightIconClassName ? ` ${rightIconClassName}` : "")
+          }
+        >
+          {rightIcon}
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/buttons/Button.tsx
+++ b/frontend/src/components/buttons/Button.tsx
@@ -32,7 +32,7 @@ export const Button = ({
       break;
   }
   return (
-    <button
+    <div
       onClick={onClick}
       className={
         styles.btn +
@@ -51,6 +51,6 @@ export const Button = ({
       >
         {_type}
       </div>
-    </button>
+    </div>
   );
 };

--- a/frontend/src/components/buttons/Button.tsx
+++ b/frontend/src/components/buttons/Button.tsx
@@ -9,6 +9,7 @@ interface Props {
   onClick?: () => void;
   flat?: boolean;
   className?: string;
+  rightButtonClassName?: string;
 }
 export const Button = ({
   type,
@@ -17,6 +18,7 @@ export const Button = ({
   Icon,
   flat,
   className,
+  rightButtonClassName,
 }: Props) => {
   let _type;
 
@@ -41,7 +43,14 @@ export const Button = ({
       <div className={styles.icon}>{Icon}</div>
       <div className={styles.label}>{label}</div>
       <div className={styles.spacer}></div>
-      <div className={styles.rightIconButton}>{_type}</div>
+      <div
+        className={
+          styles.rightIconButton +
+          (rightButtonClassName ? ` ${rightButtonClassName}` : "")
+        }
+      >
+        {_type}
+      </div>
     </button>
   );
 };

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
@@ -18,6 +18,12 @@
 .button {
   width: 100%;
 }
+.rightButtonIcon {
+  background-color: transparent;
+  :hover {
+    background-color: transparent;
+  }
+}
 
 .dropdown {
   opacity: 0;

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
@@ -28,13 +28,14 @@
 .dropdown {
   opacity: 0;
   height: 0;
-  max-width: fit-content;
   min-width: 140px;
-  margin-top: 0%;
+  margin-top: 0;
 
   display: none;
   position: absolute;
-  top: 40px;
+  left: 0;
+  right: 0;
+  top: 0;
   max-height: 460px;
   overflow: auto;
   background: #fff;
@@ -52,4 +53,57 @@
     transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94), linear;
     z-index: 2;
   }
+}
+
+.sourceSelectDropdownItem {
+  cursor: pointer;
+  user-select: none;
+
+  padding: 8px 16px;
+  display: flex;
+  max-width: 100%;
+}
+
+.selectedSource {
+  background-color: rgba(232, 240, 244, 0.4);
+}
+.activeSource {
+  background-color: rgba(0, 191, 254, 0.06);
+}
+
+.deploymentIndicator {
+  width: 12px;
+  height: 12px;
+  margin-top: 5px;
+  content: "";
+  flex: 0 0 auto;
+  border-radius: 6px;
+  background: #19bf7c;
+
+  margin-right: 8px;
+}
+
+.textContainer {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sourceName {
+  color: #2b3944;
+  line-height: 24px;
+  margin-bottom: 8px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.sourceType {
+  font-size: 14px;
+  line-height: 16px;
+  color: #475f72;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  width: 100%;
+  max-width: 100%;
 }

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
@@ -3,6 +3,7 @@ import { useListSelectionBehavior } from "../../../common/hooks/useListSelection
 import { ImgixGETSourcesData } from "../../../types";
 import { IDeploymentType } from "../../../types/imgixAPITypes";
 import { useClickOutside } from "../../forms/search/useClickOutside";
+import { DownArrowSvg } from "../../icons/DownArrowSvg";
 import { SourceMenuSvg } from "../../icons/SourceMenuSvg";
 import { Button } from "../Button";
 import styles from "./SourceSelect.module.scss";
@@ -100,11 +101,11 @@ export function SourceSelect({
       <Button
         label={activeSource?.attributes.name || "Select a Source"}
         onClick={() => setIsVisible(true)}
-        type="dropdown"
-        Icon={<SourceMenuSvg className={styles.sourceIcon} />}
+        leftIcon={<SourceMenuSvg className={styles.sourceIcon} />}
+        rightIcon={<DownArrowSvg />}
         flat={isVisible}
         className={styles.button}
-        rightButtonClassName={styles.rightButtonIcon}
+        rightIconClassName={styles.rightButtonIcon}
       />
       <ul className={styles.dropdown + (isVisible ? ` ${styles.open}` : "")}>
         {sourceList.length ? sourceList : noSourcePlaceholder}

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
@@ -64,6 +64,7 @@ export function SourceSelect({
         Icon={<SourceMenuSvg className={styles.sourceIcon} />}
         flat={isOpen}
         className={styles.button}
+        rightButtonClassName={styles.rightButtonIcon}
       />
       <ul className={styles.dropdown + (isOpen ? ` ${styles.open}` : "")}>
         {sourceList.length ? sourceList : noSourcePlaceholder}

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
@@ -56,7 +56,7 @@ export function SourceSelect({
   );
 
   return (
-    <div className={styles.container + className ? ` ${className}` : ""}>
+    <div className={styles.container + (className ? ` ${className}` : "")}>
       <Button
         label={selectedSource?.attributes.name || "Select a Source"}
         onClick={() => setIsOpen(!isOpen)}

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -24,10 +24,7 @@
   border-radius: 4px;
   flex: 1 1 auto;
   height: 40px;
-  left: 243px;
   max-height: 400px;
-  position: absolute;
-  top: 8px;
   transition: height ease-out 0.2s;
   z-index: 1;
 }

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -118,6 +118,15 @@
 .searchBaseSuggestionsListItem:first-of-type {
   padding-top: 12px;
 }
+
+.searchBaseSuggestionsListItem > div {
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline #6c7f8e;
+  }
+}
+
 .searchButtons {
   display: flex;
   align-items: center;

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -27,11 +27,11 @@
   max-height: 400px;
   transition: height ease-out 0.2s;
   z-index: 1;
-}
-// On focus, increase size of the searchContext form
-.searchContent:focus-within {
-  height: 500px;
-  transition: height ease-out 0.2s;
+
+  &.open {
+    height: 500px;
+    transition: height ease-out 0.2s;
+  }
 }
 // Form children styles
 .searchWrapper {

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -42,7 +42,6 @@
   border-radius: 3px;
   z-index: 1;
   display: flex;
-  width: 820px;
   height: 40px;
 }
 .searchWrapper:after {

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -98,6 +98,9 @@
   text-overflow: ellipsis;
   height: 20px;
 }
+.searchExpander {
+  margin-top: 50px;
+}
 .searchBaseSuggestionsList {
   position: absolute;
   left: 0px;
@@ -114,6 +117,66 @@
 }
 .searchBaseSuggestionsListItem:first-of-type {
   padding-top: 12px;
+}
+.searchButtons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  position: relative;
+  overflow: hidden;
+  height: 40px;
+  padding: 0px;
+  margin: 0px;
+}
+
+.searchButtons {
+  padding-right: 10px;
+  & .search {
+    background-color: #00bffe;
+    color: white;
+    font-style: normal;
+    font-weight: 500;
+    font-size: 13px;
+    line-height: 15px;
+    text-transform: uppercase;
+    box-shadow: 0px 2px 0px #e3e7eb;
+    & .searchIcon {
+      width: 16px;
+      height: 16px;
+      fill: white;
+      opacity: 60%;
+    }
+  }
+  & .search:hover {
+    background-color: #33ccfe;
+  }
+  & .search:active {
+    background-color: #0099cb;
+  }
+  & .clear {
+    background-color: #475f72;
+    color: white;
+    font-style: normal;
+    font-weight: 500;
+    font-size: 13px;
+    line-height: 15px;
+    text-transform: uppercase;
+    box-shadow: 0px 2px 0px #e3e7eb;
+    margin-right: 8px;
+  }
+  & .clear:hover {
+    background-color: #6c7f8e;
+  }
+  & .clear:active {
+    background-color: #394c5b;
+  }
+  & .clearIcon {
+    width: 16px;
+    height: 16px;
+    fill: #82929f;
+    opacity: 60%;
+  }
 }
 /* Search form search icon svg */
 .simpleSearchIcon > svg:not(:root) {
@@ -142,4 +205,8 @@ hr {
   height: 0;
   border-top: 1px solid rgba(0, 0, 0, 0.1);
   border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+  position: absolute;
+  top: -4px;
+  width: 97%;
+  left: 10px;
 }

--- a/frontend/src/components/forms/search/SearchBar.tsx
+++ b/frontend/src/components/forms/search/SearchBar.tsx
@@ -24,26 +24,55 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
     setQuery(e.currentTarget.value);
   };
 
+  const updateSearchHistory = (searchQuery: string) => {
+    // Add the query to the search history
+    // if the search history is longer than 4 items, remove the first item
+    const newSearchHistory = [...searchHistory];
+    if (newSearchHistory.length > 2) {
+      newSearchHistory.shift();
+    }
+    // if query is an empty string, don't add it to the search history
+    if (searchQuery !== "") {
+      newSearchHistory.push(searchQuery);
+    }
+    setSearchHistory([...newSearchHistory]);
+  };
+
+  const handleSearchSubmit = (
+    e:
+      | React.FormEvent<HTMLFormElement>
+      | React.MouseEvent<HTMLDivElement, MouseEvent>,
+    suggestedSearch?: string
+  ) => {
+    e.preventDefault();
+    const searchTerm = suggestedSearch || query;
+    handleSubmit(searchTerm);
+    updateSearchHistory(searchTerm);
+    setQuery("");
+    setIsVisible(false);
+  };
+
+  const handleInputFocus = (
+    e:
+      | React.FocusEvent<HTMLInputElement>
+      | React.MouseEvent<HTMLInputElement, MouseEvent>
+  ) => {
+    e.preventDefault();
+    setIsVisible(true);
+  };
+
+  const handleInputClear = () => {
+    setIsVisible(false);
+    setQuery("");
+  };
+
+  const inputPlaceholder =
+    placeholder || "Search by filename, path, tag, or category";
+
   return (
     <form
       className={styles.searchContent + " " + (isVisible ? styles.open : "")}
-      onSubmit={(e) => {
-        // Prevent the form from submitting, i.e. reloading the page
-        e.preventDefault();
-        // Call the handleSubmit function that was passed through props
-        handleSubmit(query);
-        // Add the query to the search history
-        // if the search history is longer than 4 items, remove the first item
-        const newSearchHistory = [...searchHistory];
-        if (newSearchHistory.length > 2) {
-          newSearchHistory.shift();
-        }
-        // if query is an empty string, don't add it to the search history
-        if (query !== "") {
-          newSearchHistory.push(query);
-        }
-        setSearchHistory([...newSearchHistory]);
-      }}
+      onSubmit={handleSearchSubmit}
     >
       <div ref={visibleRef} className={styles.searchWrapper}>
         <div className={styles.searchBase}>
@@ -55,27 +84,11 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
             <input
               type="text"
               className={styles.searchBaseInputField}
-              placeholder={
-                placeholder
-                  ? placeholder
-                  : "Search by filename, path, tag, or category"
-              }
+              placeholder={inputPlaceholder}
               value={query}
-              onChange={(event) => {
-                event.preventDefault();
-                handleInputChange(event);
-              }}
-              onSubmit={(event) => {
-                event.preventDefault();
-                handleSubmit(query);
-              }}
-              onClick={() => {
-                // let the clickOutside hook know that the search bar is visible
-                setIsVisible(true);
-              }}
-              onFocus={() => {
-                setIsVisible(true);
-              }}
+              onChange={handleInputChange}
+              onClick={handleInputFocus}
+              onFocus={handleInputFocus}
             />
           </div>
         </div>
@@ -92,34 +105,34 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
               leftIconClassName={styles.clearIcon}
               label={"Clear"}
               leftIcon={<DisabledSvg />}
+              onClick={handleInputClear}
             />
             <Button
               className={styles.search}
               leftIconClassName={styles.searchIcon}
               label={"Search"}
               leftIcon={<SearchIconSvg />}
+              onClick={handleSearchSubmit}
             />
           </div>
           <hr></hr>
           <div className={styles.searchBaseSuggestionsList}>
             <p>Recent Searches</p>
-            {searchHistory.map((search: string) =>
+            {searchHistory.map((suggestion: string, idx: number) =>
+              // if search input is not in focus, don't render anything
               // if search is empty, don't render anything
-              search.length ? (
+              isVisible && suggestion.length ? (
                 <div
                   className={styles.searchBaseSuggestionsListItem}
-                  key={search}
-                  onClick={() => {
-                    setQuery(search);
-                    handleSubmit(search);
-                  }}
+                  key={suggestion + idx}
+                  onClick={(e) => handleSearchSubmit(e, suggestion)}
                 >
                   {" "}
                   <div className={styles.searchBaseSuggestionsListItem}>
                     <div className={styles.simpleSearchIcon}>
                       <SearchIconSvg />
                     </div>
-                    {search}
+                    {suggestion}
                   </div>
                 </div>
               ) : null

--- a/frontend/src/components/forms/search/SearchBar.tsx
+++ b/frontend/src/components/forms/search/SearchBar.tsx
@@ -127,7 +127,6 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
                   key={suggestion + idx}
                   onClick={(e) => handleSearchSubmit(e, suggestion)}
                 >
-                  {" "}
                   <div className={styles.searchBaseSuggestionsListItem}>
                     <div className={styles.simpleSearchIcon}>
                       <SearchIconSvg />

--- a/frontend/src/components/forms/search/SearchBar.tsx
+++ b/frontend/src/components/forms/search/SearchBar.tsx
@@ -1,9 +1,8 @@
 import React, { ReactElement } from "react";
 import { SearchIconSvg } from "../../icons/SearchIconSvg";
+import styles from "./SearchBar.module.scss";
 import { useClickOutside } from "./useClickOutside";
 import { useLocalStorage } from "./useLocalStorage";
-import { useFocus } from "./useFocus";
-import styles from "./SearchBar.module.scss";
 
 interface Props {
   placeholder?: string;
@@ -16,8 +15,7 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
     "searchHistory",
     []
   );
-  const { visibleRef, setIsVisible } = useClickOutside(false);
-  const { focusRef, isFocused } = useFocus(false);
+  const { visibleRef, isVisible, setIsVisible } = useClickOutside(false);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.preventDefault();
@@ -26,7 +24,7 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
 
   return (
     <form
-      className={styles.searchContent}
+      className={styles.searchContent + " " + (isVisible ? styles.open : "")}
       onSubmit={(e) => {
         // Prevent the form from submitting, i.e. reloading the page
         e.preventDefault();
@@ -51,8 +49,8 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
             <div className={styles.simpleSearchIcon}>
               <SearchIconSvg />
             </div>
+            {/* TODO: handle escape key */}
             <input
-              ref={focusRef}
               type="text"
               className={styles.searchBaseInputField}
               placeholder={
@@ -66,8 +64,6 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
                 handleInputChange(event);
               }}
               onSubmit={(event) => {
-                // TODO(luis): Remove this. This is a hack to prevent the form
-                // from submitting
                 event.preventDefault();
                 handleSubmit(query);
               }}
@@ -75,10 +71,13 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
                 // let the clickOutside hook know that the search bar is visible
                 setIsVisible(true);
               }}
+              onFocus={() => {
+                setIsVisible(true);
+              }}
             />
           </div>
         </div>
-        <div className={isFocused ? styles.show : styles.hide}>
+        <div className={isVisible ? styles.show : styles.hide}>
           <div className={styles.searchBaseSuggestionsList}>
             <hr></hr>
             <p>Recent Searches</p>

--- a/frontend/src/components/forms/search/SearchBar.tsx
+++ b/frontend/src/components/forms/search/SearchBar.tsx
@@ -1,4 +1,6 @@
 import React, { ReactElement } from "react";
+import { Button } from "../../buttons/Button";
+import { DisabledSvg } from "../../icons/DisabledSvg";
 import { SearchIconSvg } from "../../icons/SearchIconSvg";
 import styles from "./SearchBar.module.scss";
 import { useClickOutside } from "./useClickOutside";
@@ -77,9 +79,29 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
             />
           </div>
         </div>
-        <div className={isVisible ? styles.show : styles.hide}>
+        <div
+          className={
+            styles.searchExpander +
+            " " +
+            (isVisible ? styles.show : styles.hide)
+          }
+        >
+          <div className={styles.searchButtons}>
+            <Button
+              className={styles.clear}
+              leftIconClassName={styles.clearIcon}
+              label={"Clear"}
+              leftIcon={<DisabledSvg />}
+            />
+            <Button
+              className={styles.search}
+              leftIconClassName={styles.searchIcon}
+              label={"Search"}
+              leftIcon={<SearchIconSvg />}
+            />
+          </div>
+          <hr></hr>
           <div className={styles.searchBaseSuggestionsList}>
-            <hr></hr>
             <p>Recent Searches</p>
             {searchHistory.map((search: string) =>
               // if search is empty, don't render anything

--- a/frontend/src/components/forms/search/useFocus.tsx
+++ b/frontend/src/components/forms/search/useFocus.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export const useFocus = (defaultState: boolean = false) => {
   const [isFocused, setIsFocused] = useState(defaultState);
@@ -14,18 +14,19 @@ export const useFocus = (defaultState: boolean = false) => {
   useEffect(() => {
     const onFocus = () => setIsFocused(true);
     const onBlur = () => setIsFocused(false);
+    const currentRef = focusRef.current;
 
     document.addEventListener("keydown", handleHide, true);
 
-    if (focusRef.current) {
-      focusRef.current.addEventListener("focus", onFocus);
-      focusRef.current.addEventListener("blur", onBlur);
+    if (currentRef) {
+      currentRef.addEventListener("focus", onFocus);
+      currentRef.addEventListener("blur", onBlur);
     }
 
     return () => {
-      if (focusRef.current) {
-        focusRef.current.removeEventListener("focus", onFocus);
-        focusRef.current.removeEventListener("blur", onBlur);
+      if (currentRef) {
+        currentRef.removeEventListener("focus", onFocus);
+        currentRef.removeEventListener("blur", onBlur);
       }
       document.removeEventListener("keydown", handleHide, true);
     };

--- a/frontend/src/components/icons/DisabledSvg.tsx
+++ b/frontend/src/components/icons/DisabledSvg.tsx
@@ -1,0 +1,22 @@
+import styles from "./Icon.module.scss";
+
+export const DisabledSvg = () => {
+  return (
+    <div className={styles.container}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g opacity="0.5">
+          <path
+            d="M8 0C3.582 0 0 3.582 0 8C0 12.418 3.582 16 8 16C12.418 16 16 12.418 16 8C16 3.582 12.418 0 8 0ZM2 8C2 6.405 2.627 4.958 3.643 3.884L10.574 13.414C9.793 13.786 8.922 14 8 14C4.686 14 2 11.314 2 8ZM12.357 12.116L5.426 2.586C6.207 2.214 7.078 2 8 2C11.314 2 14 4.686 14 8C14 9.596 13.373 11.042 12.357 12.116Z"
+            fill="white"
+          />
+        </g>
+      </svg>
+    </div>
+  );
+};

--- a/frontend/src/components/icons/SourceMenuSvg.module.scss
+++ b/frontend/src/components/icons/SourceMenuSvg.module.scss
@@ -1,8 +1,5 @@
 .svg {
-  flex: 0 0 auto;
   height: 32px;
   width: 32px;
-  margin-right: 10px;
-  overflow: hidden;
   fill: #475f72;
 }

--- a/frontend/src/components/icons/SourceMenuSvg.tsx
+++ b/frontend/src/components/icons/SourceMenuSvg.tsx
@@ -8,7 +8,7 @@ export function SourceMenuSvg({
 }): ReactElement {
   return (
     <svg
-      className={styles.svg + className ? ` ${className}` : ""}
+      className={styles.svg + (className ? ` ${className}` : "")}
       viewBox="0 0 32 32"
     >
       <path d="M22 26v-3h4v-3h4V6H10v3H6v3H2v14h20zm-1-1.3L14.5 16 10 22l-2.5-3L3 24.7V13h18v11.7zM11.9 12c-.2-.6-.8-1-1.4-1s-1.2.4-1.4 1H7v-2h18v11.7l-3-4V12H11.9zm4-3c-.2-.6-.8-1-1.4-1s-1.2.4-1.4 1H11V7h18v11.7l-3-4V9H15.9z" />

--- a/frontend/src/services/imgixAPIService.ts
+++ b/frontend/src/services/imgixAPIService.ts
@@ -52,7 +52,7 @@ export const imgixAPI = {
      */
     async get(apiKey: string) {
       return await makeRequest<ImgixGETSourcesData>({
-        url: `sources?sort=name&fields[sources]=name&filter[enabled]=true`,
+        url: `sources?sort=name&fields[sources]=name,deployment.custom_domains,deployment.type&filter[enabled]=true`,
         apiKey,
       });
     },

--- a/frontend/src/stories/Button.stories.tsx
+++ b/frontend/src/stories/Button.stories.tsx
@@ -2,10 +2,14 @@ import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Button } from "../components/buttons/Button";
 import { SourceMenuSvg } from "../components/icons/SourceMenuSvg";
+import { DownArrowSvg } from "../components/icons/DownArrowSvg";
 
 export default {
   title: "Example/Buttons",
   component: Button,
+  parameters: {
+    layout: "centered",
+  },
 } as ComponentMeta<typeof Button>;
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
@@ -18,12 +22,12 @@ BasicButton.args = {
 export const DownButton = Template.bind({});
 DownButton.args = {
   label: "Button",
-  type: "dropdown",
+  rightIcon: <DownArrowSvg />,
 };
 
 export const LibraryButton = Template.bind({});
 LibraryButton.args = {
   label: "Button",
-  type: "dropdown",
-  Icon: <SourceMenuSvg />,
+  rightIcon: <DownArrowSvg />,
+  leftIcon: <SourceMenuSvg />,
 };

--- a/frontend/src/stories/SourceSelect.stories.tsx
+++ b/frontend/src/stories/SourceSelect.stories.tsx
@@ -22,17 +22,43 @@ const Template: Story<
 const dummySourcesData = [
   {
     id: "1",
-    attributes: { name: "Source 1" },
+    attributes: {
+      name: "Source 1",
+      deployment: {
+        type: "s3",
+      },
+    },
     type: "sources",
   },
   {
     id: "2",
-    attributes: { name: "Source 2" },
+    attributes: {
+      name: "Source 2",
+      deployment: {
+        type: "gcs",
+      },
+    },
     type: "sources",
   },
   {
     id: "3",
-    attributes: { name: "Source 3" },
+    attributes: {
+      name: "Source 3",
+      deployment: {
+        type: "webfolder",
+      },
+    },
+    type: "sources",
+  },
+  {
+    id: "4",
+    attributes: {
+      name:
+        "Source With A Super Long Name That Took Me About 30 Seconds To Write",
+      deployment: {
+        type: "webfolder",
+      },
+    },
     type: "sources",
   },
 ] as ImgixGETSourcesData;

--- a/frontend/src/types/imgixAPITypes.ts
+++ b/frontend/src/types/imgixAPITypes.ts
@@ -1,7 +1,12 @@
+export type IDeploymentType = "azure" | "gcs" | "s3" | "webfolder" | "webproxy";
+
 export type ImgixGETSourcesData = {
   attributes: {
     name: string;
-    custom_domains?: string[];
+    deployment: {
+      custom_domains?: string[];
+      type: IDeploymentType;
+    };
   };
   id: string;
   type: "sources";


### PR DESCRIPTION
This PR just updates some incorrect logic to add the className in from props








<!---GHSTACKOPEN-->
### Stacked PR Chain: f-7
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#124|chore: fix layout and styles of source select and search bar |**Approved**|-|
|#125|feat(search): use hooks to style on input focus and show recent queries |**Approved**|#124|
|#126|👉 chore: fix className overriding |**Approved**|#125|
|#127|chore: layout top bar correctly |**Approved**|#126|
|#128|chore: fix left icon  |**Approved**|#127|
|#129|~~chore: update source select dropdown, and api calls ~~|**Merged**|#128|
|#131|~~chore: fix layout and styles of source select and search bar ~~|**Merged**|#129|
|#132|~~chore: have search-bar take up container width ~~|**Merged**|#131|
|#133|~~chore(search): refactor on-focus styling ~~|**Merged**|#132|
|#135|~~chore(search): add buttons to expander ~~|**Merged**|#133|
|#136|~~fix: use the active prop ~~|**Merged**|#135|
|#137|~~chore(search): refactor handlers ~~|**Merged**|#136|
|#138|~~fix: store current focus in variable ~~|**Merged**|#137|

<!---GHSTACKCLOSE-->








