### PR TITLE
chore(search): refactor on-focus styling [f-7]

### DIFF
--- a/frontend/src/common/hooks/useListSelectionBehavior.tsx
+++ b/frontend/src/common/hooks/useListSelectionBehavior.tsx
@@ -24,7 +24,6 @@ export const useListSelectionBehavior = <Item,>({
     undefined
   );
 
-
   const getIndexCurrentItem = () =>
     selectedItemUnsafe ? items.indexOf(selectedItemUnsafe) : -1;
 
@@ -66,7 +65,8 @@ export const useListSelectionBehavior = <Item,>({
         event.preventDefault();
         break;
       case "Enter":
-        onSelectCurrentItem &&
+        active &&
+          onSelectCurrentItem &&
           selectedItemUnsafe &&
           onSelectCurrentItem(selectedItemUnsafe);
         break;
@@ -85,7 +85,6 @@ export const useListSelectionBehavior = <Item,>({
     selectedItemUnsafe && items.includes(selectedItemUnsafe)
       ? selectedItemUnsafe
       : undefined;
-
 
   const handleOtherInteraction = (item: Item | undefined) => {
     setSelectedItem(item);

--- a/frontend/src/components/buttons/Button.module.scss
+++ b/frontend/src/components/buttons/Button.module.scss
@@ -7,7 +7,6 @@
   border-radius: 4px;
   background: #fff;
   color: #475f72;
-  width: 100%;
 
   &:hover {
     background-color: #e8f0f4;

--- a/frontend/src/components/buttons/Button.tsx
+++ b/frontend/src/components/buttons/Button.tsx
@@ -9,7 +9,7 @@ interface Props {
   rightIconClassName?: string;
   className?: string;
   flat?: boolean;
-  onClick?: () => void;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
 }
 export const Button = ({
   label,

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -118,6 +118,15 @@
 .searchBaseSuggestionsListItem:first-of-type {
   padding-top: 12px;
 }
+
+.searchBaseSuggestionsListItem > div {
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline #6c7f8e;
+  }
+}
+
 .searchButtons {
   display: flex;
   align-items: center;

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -27,11 +27,11 @@
   max-height: 400px;
   transition: height ease-out 0.2s;
   z-index: 1;
-}
-// On focus, increase size of the searchContext form
-.searchContent:focus-within {
-  height: 500px;
-  transition: height ease-out 0.2s;
+
+  &.open {
+    height: 500px;
+    transition: height ease-out 0.2s;
+  }
 }
 // Form children styles
 .searchWrapper {

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -98,6 +98,9 @@
   text-overflow: ellipsis;
   height: 20px;
 }
+.searchExpander {
+  margin-top: 50px;
+}
 .searchBaseSuggestionsList {
   position: absolute;
   left: 0px;
@@ -114,6 +117,66 @@
 }
 .searchBaseSuggestionsListItem:first-of-type {
   padding-top: 12px;
+}
+.searchButtons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  position: relative;
+  overflow: hidden;
+  height: 40px;
+  padding: 0px;
+  margin: 0px;
+}
+
+.searchButtons {
+  padding-right: 10px;
+  & .search {
+    background-color: #00bffe;
+    color: white;
+    font-style: normal;
+    font-weight: 500;
+    font-size: 13px;
+    line-height: 15px;
+    text-transform: uppercase;
+    box-shadow: 0px 2px 0px #e3e7eb;
+    & .searchIcon {
+      width: 16px;
+      height: 16px;
+      fill: white;
+      opacity: 60%;
+    }
+  }
+  & .search:hover {
+    background-color: #33ccfe;
+  }
+  & .search:active {
+    background-color: #0099cb;
+  }
+  & .clear {
+    background-color: #475f72;
+    color: white;
+    font-style: normal;
+    font-weight: 500;
+    font-size: 13px;
+    line-height: 15px;
+    text-transform: uppercase;
+    box-shadow: 0px 2px 0px #e3e7eb;
+    margin-right: 8px;
+  }
+  & .clear:hover {
+    background-color: #6c7f8e;
+  }
+  & .clear:active {
+    background-color: #394c5b;
+  }
+  & .clearIcon {
+    width: 16px;
+    height: 16px;
+    fill: #82929f;
+    opacity: 60%;
+  }
 }
 /* Search form search icon svg */
 .simpleSearchIcon > svg:not(:root) {
@@ -142,4 +205,8 @@ hr {
   height: 0;
   border-top: 1px solid rgba(0, 0, 0, 0.1);
   border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+  position: absolute;
+  top: -4px;
+  width: 97%;
+  left: 10px;
 }

--- a/frontend/src/components/forms/search/SearchBar.tsx
+++ b/frontend/src/components/forms/search/SearchBar.tsx
@@ -24,26 +24,55 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
     setQuery(e.currentTarget.value);
   };
 
+  const updateSearchHistory = (searchQuery: string) => {
+    // Add the query to the search history
+    // if the search history is longer than 4 items, remove the first item
+    const newSearchHistory = [...searchHistory];
+    if (newSearchHistory.length > 2) {
+      newSearchHistory.shift();
+    }
+    // if query is an empty string, don't add it to the search history
+    if (searchQuery !== "") {
+      newSearchHistory.push(searchQuery);
+    }
+    setSearchHistory([...newSearchHistory]);
+  };
+
+  const handleSearchSubmit = (
+    e:
+      | React.FormEvent<HTMLFormElement>
+      | React.MouseEvent<HTMLDivElement, MouseEvent>,
+    suggestedSearch?: string
+  ) => {
+    e.preventDefault();
+    const searchTerm = suggestedSearch || query;
+    handleSubmit(searchTerm);
+    updateSearchHistory(searchTerm);
+    setQuery("");
+    setIsVisible(false);
+  };
+
+  const handleInputFocus = (
+    e:
+      | React.FocusEvent<HTMLInputElement>
+      | React.MouseEvent<HTMLInputElement, MouseEvent>
+  ) => {
+    e.preventDefault();
+    setIsVisible(true);
+  };
+
+  const handleInputClear = () => {
+    setIsVisible(false);
+    setQuery("");
+  };
+
+  const inputPlaceholder =
+    placeholder || "Search by filename, path, tag, or category";
+
   return (
     <form
       className={styles.searchContent + " " + (isVisible ? styles.open : "")}
-      onSubmit={(e) => {
-        // Prevent the form from submitting, i.e. reloading the page
-        e.preventDefault();
-        // Call the handleSubmit function that was passed through props
-        handleSubmit(query);
-        // Add the query to the search history
-        // if the search history is longer than 4 items, remove the first item
-        const newSearchHistory = [...searchHistory];
-        if (newSearchHistory.length > 2) {
-          newSearchHistory.shift();
-        }
-        // if query is an empty string, don't add it to the search history
-        if (query !== "") {
-          newSearchHistory.push(query);
-        }
-        setSearchHistory([...newSearchHistory]);
-      }}
+      onSubmit={handleSearchSubmit}
     >
       <div ref={visibleRef} className={styles.searchWrapper}>
         <div className={styles.searchBase}>
@@ -55,27 +84,11 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
             <input
               type="text"
               className={styles.searchBaseInputField}
-              placeholder={
-                placeholder
-                  ? placeholder
-                  : "Search by filename, path, tag, or category"
-              }
+              placeholder={inputPlaceholder}
               value={query}
-              onChange={(event) => {
-                event.preventDefault();
-                handleInputChange(event);
-              }}
-              onSubmit={(event) => {
-                event.preventDefault();
-                handleSubmit(query);
-              }}
-              onClick={() => {
-                // let the clickOutside hook know that the search bar is visible
-                setIsVisible(true);
-              }}
-              onFocus={() => {
-                setIsVisible(true);
-              }}
+              onChange={handleInputChange}
+              onClick={handleInputFocus}
+              onFocus={handleInputFocus}
             />
           </div>
         </div>
@@ -92,34 +105,34 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
               leftIconClassName={styles.clearIcon}
               label={"Clear"}
               leftIcon={<DisabledSvg />}
+              onClick={handleInputClear}
             />
             <Button
               className={styles.search}
               leftIconClassName={styles.searchIcon}
               label={"Search"}
               leftIcon={<SearchIconSvg />}
+              onClick={handleSearchSubmit}
             />
           </div>
           <hr></hr>
           <div className={styles.searchBaseSuggestionsList}>
             <p>Recent Searches</p>
-            {searchHistory.map((search: string) =>
+            {searchHistory.map((suggestion: string, idx: number) =>
+              // if search input is not in focus, don't render anything
               // if search is empty, don't render anything
-              search.length ? (
+              isVisible && suggestion.length ? (
                 <div
                   className={styles.searchBaseSuggestionsListItem}
-                  key={search}
-                  onClick={() => {
-                    setQuery(search);
-                    handleSubmit(search);
-                  }}
+                  key={suggestion + idx}
+                  onClick={(e) => handleSearchSubmit(e, suggestion)}
                 >
                   {" "}
                   <div className={styles.searchBaseSuggestionsListItem}>
                     <div className={styles.simpleSearchIcon}>
                       <SearchIconSvg />
                     </div>
-                    {search}
+                    {suggestion}
                   </div>
                 </div>
               ) : null

--- a/frontend/src/components/forms/search/SearchBar.tsx
+++ b/frontend/src/components/forms/search/SearchBar.tsx
@@ -127,7 +127,6 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
                   key={suggestion + idx}
                   onClick={(e) => handleSearchSubmit(e, suggestion)}
                 >
-                  {" "}
                   <div className={styles.searchBaseSuggestionsListItem}>
                     <div className={styles.simpleSearchIcon}>
                       <SearchIconSvg />

--- a/frontend/src/components/forms/search/SearchBar.tsx
+++ b/frontend/src/components/forms/search/SearchBar.tsx
@@ -1,9 +1,8 @@
 import React, { ReactElement } from "react";
 import { SearchIconSvg } from "../../icons/SearchIconSvg";
+import styles from "./SearchBar.module.scss";
 import { useClickOutside } from "./useClickOutside";
 import { useLocalStorage } from "./useLocalStorage";
-import { useFocus } from "./useFocus";
-import styles from "./SearchBar.module.scss";
 
 interface Props {
   placeholder?: string;
@@ -16,8 +15,7 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
     "searchHistory",
     []
   );
-  const { visibleRef, setIsVisible } = useClickOutside(false);
-  const { focusRef, isFocused } = useFocus(false);
+  const { visibleRef, isVisible, setIsVisible } = useClickOutside(false);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.preventDefault();
@@ -26,7 +24,7 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
 
   return (
     <form
-      className={styles.searchContent}
+      className={styles.searchContent + " " + (isVisible ? styles.open : "")}
       onSubmit={(e) => {
         // Prevent the form from submitting, i.e. reloading the page
         e.preventDefault();
@@ -51,8 +49,8 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
             <div className={styles.simpleSearchIcon}>
               <SearchIconSvg />
             </div>
+            {/* TODO: handle escape key */}
             <input
-              ref={focusRef}
               type="text"
               className={styles.searchBaseInputField}
               placeholder={
@@ -66,8 +64,6 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
                 handleInputChange(event);
               }}
               onSubmit={(event) => {
-                // TODO(luis): Remove this. This is a hack to prevent the form
-                // from submitting
                 event.preventDefault();
                 handleSubmit(query);
               }}
@@ -75,10 +71,13 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
                 // let the clickOutside hook know that the search bar is visible
                 setIsVisible(true);
               }}
+              onFocus={() => {
+                setIsVisible(true);
+              }}
             />
           </div>
         </div>
-        <div className={isFocused ? styles.show : styles.hide}>
+        <div className={isVisible ? styles.show : styles.hide}>
           <div className={styles.searchBaseSuggestionsList}>
             <hr></hr>
             <p>Recent Searches</p>

--- a/frontend/src/components/forms/search/SearchBar.tsx
+++ b/frontend/src/components/forms/search/SearchBar.tsx
@@ -1,4 +1,6 @@
 import React, { ReactElement } from "react";
+import { Button } from "../../buttons/Button";
+import { DisabledSvg } from "../../icons/DisabledSvg";
 import { SearchIconSvg } from "../../icons/SearchIconSvg";
 import styles from "./SearchBar.module.scss";
 import { useClickOutside } from "./useClickOutside";
@@ -77,9 +79,29 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
             />
           </div>
         </div>
-        <div className={isVisible ? styles.show : styles.hide}>
+        <div
+          className={
+            styles.searchExpander +
+            " " +
+            (isVisible ? styles.show : styles.hide)
+          }
+        >
+          <div className={styles.searchButtons}>
+            <Button
+              className={styles.clear}
+              leftIconClassName={styles.clearIcon}
+              label={"Clear"}
+              leftIcon={<DisabledSvg />}
+            />
+            <Button
+              className={styles.search}
+              leftIconClassName={styles.searchIcon}
+              label={"Search"}
+              leftIcon={<SearchIconSvg />}
+            />
+          </div>
+          <hr></hr>
           <div className={styles.searchBaseSuggestionsList}>
-            <hr></hr>
             <p>Recent Searches</p>
             {searchHistory.map((search: string) =>
               // if search is empty, don't render anything

--- a/frontend/src/components/forms/search/useFocus.tsx
+++ b/frontend/src/components/forms/search/useFocus.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export const useFocus = (defaultState: boolean = false) => {
   const [isFocused, setIsFocused] = useState(defaultState);
@@ -14,18 +14,19 @@ export const useFocus = (defaultState: boolean = false) => {
   useEffect(() => {
     const onFocus = () => setIsFocused(true);
     const onBlur = () => setIsFocused(false);
+    const currentRef = focusRef.current;
 
     document.addEventListener("keydown", handleHide, true);
 
-    if (focusRef.current) {
-      focusRef.current.addEventListener("focus", onFocus);
-      focusRef.current.addEventListener("blur", onBlur);
+    if (currentRef) {
+      currentRef.addEventListener("focus", onFocus);
+      currentRef.addEventListener("blur", onBlur);
     }
 
     return () => {
-      if (focusRef.current) {
-        focusRef.current.removeEventListener("focus", onFocus);
-        focusRef.current.removeEventListener("blur", onBlur);
+      if (currentRef) {
+        currentRef.removeEventListener("focus", onFocus);
+        currentRef.removeEventListener("blur", onBlur);
       }
       document.removeEventListener("keydown", handleHide, true);
     };

--- a/frontend/src/components/icons/DisabledSvg.tsx
+++ b/frontend/src/components/icons/DisabledSvg.tsx
@@ -1,0 +1,22 @@
+import styles from "./Icon.module.scss";
+
+export const DisabledSvg = () => {
+  return (
+    <div className={styles.container}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g opacity="0.5">
+          <path
+            d="M8 0C3.582 0 0 3.582 0 8C0 12.418 3.582 16 8 16C12.418 16 16 12.418 16 8C16 3.582 12.418 0 8 0ZM2 8C2 6.405 2.627 4.958 3.643 3.884L10.574 13.414C9.793 13.786 8.922 14 8 14C4.686 14 2 11.314 2 8ZM12.357 12.116L5.426 2.586C6.207 2.214 7.078 2 8 2C11.314 2 14 4.686 14 8C14 9.596 13.373 11.042 12.357 12.116Z"
+            fill="white"
+          />
+        </g>
+      </svg>
+    </div>
+  );
+};


### PR DESCRIPTION
This commit removes the `:focus-within` styling and instead uses the `isVisible` hook to conditionally style the search bar on input focus.




<!---GHSTACKOPEN-->
### Stacked PR Chain: f-7
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#124|chore: fix layout and styles of source select and search bar |**Approved**|-|
|#125|feat(search): use hooks to style on input focus and show recent queries |**Approved**|#124|
|#126|chore: fix className overriding |**Approved**|#125|
|#127|chore: layout top bar correctly |**Approved**|#126|
|#128|chore: fix left icon  |**Approved**|#127|
|#129|chore: update source select dropdown, and api calls |**Approved**|#128|
|#131|chore: fix layout and styles of source select and search bar |**Approved**|#129|
|#132|chore: have search-bar take up container width |**Approved**|#131|
|#133|👉 chore(search): refactor on-focus styling |**Approved**|#132|
|#135|chore(search): add buttons to expander |**Approved**|#133|
|#136|fix: use the active prop |**Approved**|#135|
|#137|chore(search): refactor handlers |**Approved**|#136|
|#138|fix: store current focus in variable |**Approved**|#137|

<!---GHSTACKCLOSE-->




