### PR TITLE
fix: use the active prop [f-7]

### DIFF
--- a/frontend/src/common/hooks/useListSelectionBehavior.tsx
+++ b/frontend/src/common/hooks/useListSelectionBehavior.tsx
@@ -24,7 +24,6 @@ export const useListSelectionBehavior = <Item,>({
     undefined
   );
 
-
   const getIndexCurrentItem = () =>
     selectedItemUnsafe ? items.indexOf(selectedItemUnsafe) : -1;
 
@@ -66,7 +65,8 @@ export const useListSelectionBehavior = <Item,>({
         event.preventDefault();
         break;
       case "Enter":
-        onSelectCurrentItem &&
+        active &&
+          onSelectCurrentItem &&
           selectedItemUnsafe &&
           onSelectCurrentItem(selectedItemUnsafe);
         break;
@@ -85,7 +85,6 @@ export const useListSelectionBehavior = <Item,>({
     selectedItemUnsafe && items.includes(selectedItemUnsafe)
       ? selectedItemUnsafe
       : undefined;
-
 
   const handleOtherInteraction = (item: Item | undefined) => {
     setSelectedItem(item);

--- a/frontend/src/components/buttons/Button.module.scss
+++ b/frontend/src/components/buttons/Button.module.scss
@@ -7,7 +7,6 @@
   border-radius: 4px;
   background: #fff;
   color: #475f72;
-  width: 100%;
 
   &:hover {
     background-color: #e8f0f4;

--- a/frontend/src/components/buttons/Button.tsx
+++ b/frontend/src/components/buttons/Button.tsx
@@ -9,7 +9,7 @@ interface Props {
   rightIconClassName?: string;
   className?: string;
   flat?: boolean;
-  onClick?: () => void;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
 }
 export const Button = ({
   label,

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -118,6 +118,15 @@
 .searchBaseSuggestionsListItem:first-of-type {
   padding-top: 12px;
 }
+
+.searchBaseSuggestionsListItem > div {
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline #6c7f8e;
+  }
+}
+
 .searchButtons {
   display: flex;
   align-items: center;

--- a/frontend/src/components/forms/search/SearchBar.tsx
+++ b/frontend/src/components/forms/search/SearchBar.tsx
@@ -24,26 +24,55 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
     setQuery(e.currentTarget.value);
   };
 
+  const updateSearchHistory = (searchQuery: string) => {
+    // Add the query to the search history
+    // if the search history is longer than 4 items, remove the first item
+    const newSearchHistory = [...searchHistory];
+    if (newSearchHistory.length > 2) {
+      newSearchHistory.shift();
+    }
+    // if query is an empty string, don't add it to the search history
+    if (searchQuery !== "") {
+      newSearchHistory.push(searchQuery);
+    }
+    setSearchHistory([...newSearchHistory]);
+  };
+
+  const handleSearchSubmit = (
+    e:
+      | React.FormEvent<HTMLFormElement>
+      | React.MouseEvent<HTMLDivElement, MouseEvent>,
+    suggestedSearch?: string
+  ) => {
+    e.preventDefault();
+    const searchTerm = suggestedSearch || query;
+    handleSubmit(searchTerm);
+    updateSearchHistory(searchTerm);
+    setQuery("");
+    setIsVisible(false);
+  };
+
+  const handleInputFocus = (
+    e:
+      | React.FocusEvent<HTMLInputElement>
+      | React.MouseEvent<HTMLInputElement, MouseEvent>
+  ) => {
+    e.preventDefault();
+    setIsVisible(true);
+  };
+
+  const handleInputClear = () => {
+    setIsVisible(false);
+    setQuery("");
+  };
+
+  const inputPlaceholder =
+    placeholder || "Search by filename, path, tag, or category";
+
   return (
     <form
       className={styles.searchContent + " " + (isVisible ? styles.open : "")}
-      onSubmit={(e) => {
-        // Prevent the form from submitting, i.e. reloading the page
-        e.preventDefault();
-        // Call the handleSubmit function that was passed through props
-        handleSubmit(query);
-        // Add the query to the search history
-        // if the search history is longer than 4 items, remove the first item
-        const newSearchHistory = [...searchHistory];
-        if (newSearchHistory.length > 2) {
-          newSearchHistory.shift();
-        }
-        // if query is an empty string, don't add it to the search history
-        if (query !== "") {
-          newSearchHistory.push(query);
-        }
-        setSearchHistory([...newSearchHistory]);
-      }}
+      onSubmit={handleSearchSubmit}
     >
       <div ref={visibleRef} className={styles.searchWrapper}>
         <div className={styles.searchBase}>
@@ -55,27 +84,11 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
             <input
               type="text"
               className={styles.searchBaseInputField}
-              placeholder={
-                placeholder
-                  ? placeholder
-                  : "Search by filename, path, tag, or category"
-              }
+              placeholder={inputPlaceholder}
               value={query}
-              onChange={(event) => {
-                event.preventDefault();
-                handleInputChange(event);
-              }}
-              onSubmit={(event) => {
-                event.preventDefault();
-                handleSubmit(query);
-              }}
-              onClick={() => {
-                // let the clickOutside hook know that the search bar is visible
-                setIsVisible(true);
-              }}
-              onFocus={() => {
-                setIsVisible(true);
-              }}
+              onChange={handleInputChange}
+              onClick={handleInputFocus}
+              onFocus={handleInputFocus}
             />
           </div>
         </div>
@@ -92,34 +105,34 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
               leftIconClassName={styles.clearIcon}
               label={"Clear"}
               leftIcon={<DisabledSvg />}
+              onClick={handleInputClear}
             />
             <Button
               className={styles.search}
               leftIconClassName={styles.searchIcon}
               label={"Search"}
               leftIcon={<SearchIconSvg />}
+              onClick={handleSearchSubmit}
             />
           </div>
           <hr></hr>
           <div className={styles.searchBaseSuggestionsList}>
             <p>Recent Searches</p>
-            {searchHistory.map((search: string) =>
+            {searchHistory.map((suggestion: string, idx: number) =>
+              // if search input is not in focus, don't render anything
               // if search is empty, don't render anything
-              search.length ? (
+              isVisible && suggestion.length ? (
                 <div
                   className={styles.searchBaseSuggestionsListItem}
-                  key={search}
-                  onClick={() => {
-                    setQuery(search);
-                    handleSubmit(search);
-                  }}
+                  key={suggestion + idx}
+                  onClick={(e) => handleSearchSubmit(e, suggestion)}
                 >
                   {" "}
                   <div className={styles.searchBaseSuggestionsListItem}>
                     <div className={styles.simpleSearchIcon}>
                       <SearchIconSvg />
                     </div>
-                    {search}
+                    {suggestion}
                   </div>
                 </div>
               ) : null

--- a/frontend/src/components/forms/search/SearchBar.tsx
+++ b/frontend/src/components/forms/search/SearchBar.tsx
@@ -127,7 +127,6 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
                   key={suggestion + idx}
                   onClick={(e) => handleSearchSubmit(e, suggestion)}
                 >
-                  {" "}
                   <div className={styles.searchBaseSuggestionsListItem}>
                     <div className={styles.simpleSearchIcon}>
                       <SearchIconSvg />

--- a/frontend/src/components/forms/search/useFocus.tsx
+++ b/frontend/src/components/forms/search/useFocus.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export const useFocus = (defaultState: boolean = false) => {
   const [isFocused, setIsFocused] = useState(defaultState);
@@ -14,18 +14,19 @@ export const useFocus = (defaultState: boolean = false) => {
   useEffect(() => {
     const onFocus = () => setIsFocused(true);
     const onBlur = () => setIsFocused(false);
+    const currentRef = focusRef.current;
 
     document.addEventListener("keydown", handleHide, true);
 
-    if (focusRef.current) {
-      focusRef.current.addEventListener("focus", onFocus);
-      focusRef.current.addEventListener("blur", onBlur);
+    if (currentRef) {
+      currentRef.addEventListener("focus", onFocus);
+      currentRef.addEventListener("blur", onBlur);
     }
 
     return () => {
-      if (focusRef.current) {
-        focusRef.current.removeEventListener("focus", onFocus);
-        focusRef.current.removeEventListener("blur", onBlur);
+      if (currentRef) {
+        currentRef.removeEventListener("focus", onFocus);
+        currentRef.removeEventListener("blur", onBlur);
       }
       document.removeEventListener("keydown", handleHide, true);
     };


### PR DESCRIPTION
This commit has the hook make use of its `active` prop. This prop allows us to enable/disable functionality depending on whether or not the element that uses this hook is "active". In our case, when the user is no longer navigating the dropdown the "Enter" event listener should do nothing inside this hook.

## Before this commit
`active` prop was not being used, leaving the `Enter` keypress listener to fire unintentionally.

## After this commit
The `active` prop has to be truthy in order for the `Enter` event to fire.

This fixes a bug where the "Enter" keypress would always cause a source ID update, regardless of what DOM node triggered the event.



<!---GHSTACKOPEN-->
### Stacked PR Chain: f-7
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#124|chore: fix layout and styles of source select and search bar |**Approved**|-|
|#125|feat(search): use hooks to style on input focus and show recent queries |**Approved**|#124|
|#126|chore: fix className overriding |**Approved**|#125|
|#127|chore: layout top bar correctly |**Approved**|#126|
|#128|chore: fix left icon  |**Approved**|#127|
|#129|chore: update source select dropdown, and api calls |**Approved**|#128|
|#131|chore: fix layout and styles of source select and search bar |**Approved**|#129|
|#132|chore: have search-bar take up container width |**Approved**|#131|
|#133|chore(search): refactor on-focus styling |**Approved**|#132|
|#135|chore(search): add buttons to expander |**Approved**|#133|
|#136|👉 fix: use the active prop |**Approved**|#135|
|#137|chore(search): refactor handlers |**Approved**|#136|
|#138|fix: store current focus in variable |**Approved**|#137|

<!---GHSTACKCLOSE-->


