### PR TITLE
fix: store current focus in variable [f-7]

### DIFF
--- a/frontend/src/components/forms/search/useFocus.tsx
+++ b/frontend/src/components/forms/search/useFocus.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export const useFocus = (defaultState: boolean = false) => {
   const [isFocused, setIsFocused] = useState(defaultState);
@@ -14,18 +14,19 @@ export const useFocus = (defaultState: boolean = false) => {
   useEffect(() => {
     const onFocus = () => setIsFocused(true);
     const onBlur = () => setIsFocused(false);
+    const currentRef = focusRef.current;
 
     document.addEventListener("keydown", handleHide, true);
 
-    if (focusRef.current) {
-      focusRef.current.addEventListener("focus", onFocus);
-      focusRef.current.addEventListener("blur", onBlur);
+    if (currentRef) {
+      currentRef.addEventListener("focus", onFocus);
+      currentRef.addEventListener("blur", onBlur);
     }
 
     return () => {
-      if (focusRef.current) {
-        focusRef.current.removeEventListener("focus", onFocus);
-        focusRef.current.removeEventListener("blur", onBlur);
+      if (currentRef) {
+        currentRef.removeEventListener("focus", onFocus);
+        currentRef.removeEventListener("blur", onBlur);
       }
       document.removeEventListener("keydown", handleHide, true);
     };


### PR DESCRIPTION
This commit copies 'focusRef.current' to a variable inside the `useEffect`. This fixes an issue in CI where the linter warned "The ref value 'focusRef.current' will likely have changed by the time this effect cleanup function runs."

<!---GHSTACKOPEN-->
### Stacked PR Chain: f-7
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#124|chore: fix layout and styles of source select and search bar |**Approved**|-|
|#125|feat(search): use hooks to style on input focus and show recent queries |**Approved**|#124|
|#126|chore: fix className overriding |**Approved**|#125|
|#127|chore: layout top bar correctly |**Approved**|#126|
|#128|chore: fix left icon  |**Approved**|#127|
|#129|chore: update source select dropdown, and api calls |**Approved**|#128|
|#131|chore: fix layout and styles of source select and search bar |**Approved**|#129|
|#132|chore: have search-bar take up container width |**Approved**|#131|
|#133|chore(search): refactor on-focus styling |**Approved**|#132|
|#135|chore(search): add buttons to expander |**Approved**|#133|
|#136|fix: use the active prop |**Approved**|#135|
|#137|chore(search): refactor handlers |**Approved**|#136|
|#138|👉 fix: store current focus in variable |**Approved**|#137|

<!---GHSTACKCLOSE-->

