### PR TITLE
fix(search): button opacity

### DIFF
--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -154,7 +154,7 @@
       width: 16px;
       height: 16px;
       fill: white;
-      opacity: 60%;
+      opacity: 0.6;
     }
   }
   & .search:hover {
@@ -184,7 +184,7 @@
     width: 16px;
     height: 16px;
     fill: #82929f;
-    opacity: 60%;
+    opacity: 0.6;
   }
 }
 /* Search form search icon svg */


### PR DESCRIPTION
This commit changes the button opacities from `60%` to `0.6`. This fixes an issue where when the CSS is bundled, the opacity was being set to `1%`.