### PR TITLE
feat(source-select): add source type icons

### DIFF
--- a/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
@@ -106,4 +106,13 @@
   text-overflow: ellipsis;
   width: 100%;
   max-width: 100%;
+  display: flex;
+  flex-direction: row;
+  flex-basis: max-content;
+}
+.sourceTypeIcon {
+  & path {
+    fill: #6c7f8e;
+  }
+  margin-left: 8px;
 }

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.tsx
@@ -5,6 +5,7 @@ import { IDeploymentType } from "../../../types/imgixAPITypes";
 import { useClickOutside } from "../../forms/search/useClickOutside";
 import { DownArrowSvg } from "../../icons/DownArrowSvg";
 import { SourceMenuSvg } from "../../icons/SourceMenuSvg";
+import { SourceTypeIcon } from "../../icons/SourceTypeIcon";
 import { Button } from "../Button";
 import styles from "./SourceSelect.module.scss";
 
@@ -81,6 +82,10 @@ export function SourceSelect({
           <div className={styles.sourceName}>{source.attributes.name}</div>
           <div className={styles.sourceType}>
             {SOURCE_MAP_DICTIONARY[source.attributes.deployment.type]}
+            <SourceTypeIcon
+              type={source.attributes.deployment.type}
+              className={styles.sourceTypeIcon}
+            />
           </div>
         </div>
       </li>

--- a/frontend/src/components/icons/AzureIcon.tsx
+++ b/frontend/src/components/icons/AzureIcon.tsx
@@ -1,0 +1,25 @@
+import React, { ReactElement } from "react";
+import styles from "./Icon.module.scss";
+
+export const AzureIcon = ({
+  className,
+}: {
+  className?: string;
+}): ReactElement => {
+  return (
+    <div className={styles.container + (className ? ` ${className}` : "")}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M16 13.5L9.9 2.9L7.6 7.6L11.8 12.4L4 13.4L16 13.5ZM4 5.5L0 12.3L3.4 12L9.4 1L4 5.5Z"
+          fill="black"
+        />
+      </svg>
+    </div>
+  );
+};

--- a/frontend/src/components/icons/GCSIcon.tsx
+++ b/frontend/src/components/icons/GCSIcon.tsx
@@ -1,0 +1,37 @@
+import React, { ReactElement } from "react";
+import styles from "./Icon.module.scss";
+
+export const GCSIcon = ({
+  className,
+}: {
+  className?: string;
+}): ReactElement => {
+  return (
+    <div className={styles.container + (className ? ` ${className}` : "")}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10Z"
+          fill="black"
+        />
+        <path
+          d="M2.19995 4L3.89995 7L5.39995 4.5C5.49995 4.2 5.89995 4 6.19995 4H13.7L12.3 1.5C12.1 1.2 11.8 1 11.4 1H4.49995C4.19995 1 3.79995 1.2 3.69995 1.5L2.19995 4Z"
+          fill="black"
+        />
+        <path
+          d="M7.50002 15L9.20002 12H6.30002C5.90002 12 5.60002 11.8 5.40002 11.5L1.70002 5.09998L0.300024 7.49998C0.100024 7.79998 0.100024 8.19998 0.300024 8.49998L3.80002 14.5C4.00002 14.8 4.30002 15 4.60002 15H7.50002Z"
+          fill="black"
+        />
+        <path
+          d="M14.3 5H10.9L12.3 7.5C12.5 7.8 12.5 8.2 12.3 8.5L8.59998 15H11.4C11.8 15 12.1 14.8 12.3 14.5L15.7 8.5C15.9 8.2 15.9 7.8 15.7 7.5L14.3 5Z"
+          fill="black"
+        />
+      </svg>
+    </div>
+  );
+};

--- a/frontend/src/components/icons/S3Icon.tsx
+++ b/frontend/src/components/icons/S3Icon.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement } from "react";
+import styles from "./Icon.module.scss";
+
+export const S3Icon = ({ className }: { className?: string }): ReactElement => {
+  return (
+    <div className={styles.container + (className ? ` ${className}` : "")}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M7 15L0 12V4L7 6V15ZM9 15L16 12V4L9 6V15ZM1 3L8 5L15 3L8.031 1L1 3Z"
+          fill="black"
+        />
+      </svg>
+    </div>
+  );
+};

--- a/frontend/src/components/icons/SearchIconSvg.tsx
+++ b/frontend/src/components/icons/SearchIconSvg.tsx
@@ -1,10 +1,23 @@
 import React, { ReactElement } from "react";
-
-export function SearchIconSvg(): ReactElement {
+import styles from "./Icon.module.scss";
+export const SearchIconSvg = ({
+  className,
+}: {
+  className?: string;
+}): ReactElement => {
   return (
-    <svg id="search" viewBox="0 0 24 24">
-      {" "}
-      <path d="M17.9,13.9c0.7-1.3,1.1-2.8,1.1-4.4C19,4.3,14.7,0,9.5,0S0,4.3,0,9.5S4.3,19,9.5,19c1.6,0,3.1-0.4,4.4-1.1L20,24l4-4 L17.9,13.9z M9.5,15C6.5,15,4,12.5,4,9.5C4,6.5,6.5,4,9.5,4S15,6.5,15,9.5C15,12.5,12.5,15,9.5,15z"></path>{" "}
-    </svg>
+    <div className={styles.container + (className ? ` ${className}` : "")}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="#475f72"
+      >
+        <g>
+          <path d="M16 14L11.12 9.12C11.67 8.21 12 7.14 12 6C12 2.69 9.31 0 6 0C2.69 0 0 2.69 0 6C0 9.31 2.69 12 6 12C7.14 12 8.21 11.67 9.12 11.12L14 16L16 14ZM6 10C3.79 10 2 8.21 2 6C2 3.79 3.79 2 6 2C8.21 2 10 3.79 10 6C10 8.21 8.21 10 6 10Z" />
+        </g>
+      </svg>
+    </div>
   );
-}
+};

--- a/frontend/src/components/icons/SourceTypeIcon.tsx
+++ b/frontend/src/components/icons/SourceTypeIcon.tsx
@@ -1,0 +1,29 @@
+import { IDeploymentType } from "../../types/imgixAPITypes";
+import { AzureIcon } from "./AzureIcon";
+import { GCSIcon } from "./GCSIcon";
+import { S3Icon } from "./S3Icon";
+import { WebFolderIcon } from "./WebFolderIcon";
+import { WebProxyIcon } from "./WebProxyIcon";
+
+export const SourceTypeIcon = ({
+  type,
+  className,
+}: {
+  type: IDeploymentType;
+  className: string;
+}) => {
+  switch (type) {
+    case "azure":
+      return <AzureIcon className={className} />;
+    case "gcs":
+      return <GCSIcon className={className} />;
+    case "s3":
+      return <S3Icon className={className} />;
+    case "webfolder":
+      return <WebFolderIcon className={className} />;
+    case "webproxy":
+      return <WebProxyIcon className={className} />;
+    default:
+      return null;
+  }
+};

--- a/frontend/src/components/icons/WebFolderIcon.tsx
+++ b/frontend/src/components/icons/WebFolderIcon.tsx
@@ -1,0 +1,29 @@
+import React, { ReactElement } from "react";
+import styles from "./Icon.module.scss";
+
+export const WebFolderIcon = ({
+  className,
+}: {
+  className?: string;
+}): ReactElement => {
+  return (
+    <div className={styles.container + (className ? ` ${className}` : "")}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M16 13C16 13.552 15.552 14 15 14H2V6C2 5.448 2.448 5 3 5H16V13Z"
+          fill="black"
+        />
+        <path
+          d="M4 3C4 2.448 3.552 2 3 2H1C0.448 2 0 2.448 0 3V13C0 13.552 0.448 14 1 14V5C1 4.448 1.448 4 2 4H14C14 3.448 13.552 3 13 3H4Z"
+          fill="black"
+        />
+      </svg>
+    </div>
+  );
+};

--- a/frontend/src/components/icons/WebProxyIcon.tsx
+++ b/frontend/src/components/icons/WebProxyIcon.tsx
@@ -8,10 +8,7 @@ export const WebProxyIcon = ({
 }): ReactElement => {
   return (
     <div className={styles.container + (className ? ` ${className}` : "")}>
-      <svg
-        className={styles.svg + (className ? ` ${className}` : "")}
-        viewBox="0 0 32 32"
-      >
+      <svg width="16" height="16" viewBox="0 0 16 16">
         <path
           d="M16 2V14H14C13.448 14 13 13.552 13 13V12H3V13C3 13.552 2.552 14 2 14H0V2H2C2.552 2 3 2.448 3 3V4H13V3C13 2.448 13.448 2 14 2H16ZM5 7H3V9H5V7ZM9 7H7V9H9V7ZM13 7H11V9H13V7Z"
           fill="black"

--- a/frontend/src/components/icons/WebProxyIcon.tsx
+++ b/frontend/src/components/icons/WebProxyIcon.tsx
@@ -1,0 +1,22 @@
+import React, { ReactElement } from "react";
+import styles from "./Icon.module.scss";
+
+export const WebProxyIcon = ({
+  className,
+}: {
+  className?: string;
+}): ReactElement => {
+  return (
+    <div className={styles.container + (className ? ` ${className}` : "")}>
+      <svg
+        className={styles.svg + (className ? ` ${className}` : "")}
+        viewBox="0 0 32 32"
+      >
+        <path
+          d="M16 2V14H14C13.448 14 13 13.552 13 13V12H3V13C3 13.552 2.552 14 2 14H0V2H2C2.552 2 3 2.448 3 3V4H13V3C13 2.448 13.448 2 14 2H16ZM5 7H3V9H5V7ZM9 7H7V9H9V7ZM13 7H11V9H13V7Z"
+          fill="black"
+        />
+      </svg>
+    </div>
+  );
+};


### PR DESCRIPTION
This PR creates Icon files for GCS, AWS, Azure, WebProxy, and WebFolder source types.

## Before this PR
Source select dropdown types did not display an icon for each type of source

## After this PR
Source select dropdown source types display an icon for each source type

## Screenshot 🖼️ 
![image](https://user-images.githubusercontent.com/16711614/145431308-fbb865e3-1b92-4945-b74c-557a84981cea.png)
