### PR TITLE
chore(search): sort by newest

### DIFF
--- a/frontend/src/services/imgixAPIService.ts
+++ b/frontend/src/services/imgixAPIService.ts
@@ -71,7 +71,7 @@ export const imgixAPI = {
       ) {
         // ?page[number]=${n}&page[size]=18`
         return await makeRequest<ImgixGETAssetsData>({
-          url: `assets/${sourceId}?page[cursor]=${index}&page[limit]=${size}&sort=date_created&fields[assets]=name,description,origin_path,media_height,media_width`,
+          url: `assets/${sourceId}?page[cursor]=${index}&page[limit]=${size}&sort=-date_created&fields[assets]=name,description,origin_path,media_height,media_width`,
           apiKey,
         });
       },

--- a/frontend/src/tests/services/imgixAPIService.test.ts
+++ b/frontend/src/tests/services/imgixAPIService.test.ts
@@ -69,7 +69,7 @@ test("should return assets in date modified descending order", async () => {
 
   const requestedUrl = mockRequest.mock.calls[0][0];
   const requestedURI = new URI(requestedUrl);
-  expect(requestedURI.getQueryParamValue("sort")).toBe("date_created");
+  expect(requestedURI.getQueryParamValue("sort")).toBe("-date_created");
 });
 
 test("should return name, description, and origin_path information", async () => {


### PR DESCRIPTION
This commit changes the sort param to be by `-date_created`, resulting in search assets being displayed from newest to oldest.

## Before this commit
Search results were displayed from oldest to newest.

## After this commit
Search results are displayed from newest to oldest. They appear in the same order as the imgix Image Manager.