### PR TITLE
chore(search): increase page limit to fourteen

### DIFF
--- a/frontend/src/components/AssetBrowser/AssetBrowserContainer.tsx
+++ b/frontend/src/components/AssetBrowser/AssetBrowserContainer.tsx
@@ -5,7 +5,7 @@ import { IBreakoutAppOnSubmit } from "../../types/breakoutAppPublic";
 import { IPaginationData } from "../Pagination/Pagination";
 import { AssetBrowser } from "./AssetBrowser";
 
-const CURSOR_PAGE_LIMIT = 12;
+const CURSOR_PAGE_LIMIT = 14;
 
 interface Props {
   apiKey: string | null;

--- a/frontend/src/services/imgixAPIService.ts
+++ b/frontend/src/services/imgixAPIService.ts
@@ -67,7 +67,7 @@ export const imgixAPI = {
         apiKey: string,
         sourceId: string,
         index: string = "0",
-        size: string = "12"
+        size: string = "14"
       ) {
         // ?page[number]=${n}&page[size]=18`
         return await makeRequest<ImgixGETAssetsData>({
@@ -90,7 +90,7 @@ export const imgixAPI = {
       sourceId: string,
       query: string,
       index: string = "0",
-      size: string = "12"
+      size: string = "14"
     ) {
       // TODO(luis): use a search endpoint rather than the assets endpoint
       // build the filter portion of the query


### PR DESCRIPTION
This commit increased the asset-grid-item count from 12 to 14. This addresses an issue where, on larger screen sizes, there were too few elements being displayed.

## Before
![Screen Shot 2021-12-14 at 11 19 25 AM](https://user-images.githubusercontent.com/16711614/146043054-70a11714-0b7d-42b3-83d8-cafe242de032.png)


## After
![Screen Shot 2021-12-14 at 11 53 18 AM](https://user-images.githubusercontent.com/16711614/146043070-91fe6af6-ad25-420e-988e-9ce565fe86f3.png)

