### PR TITLE
chore: add comment explaining reducer func

### DIFF
--- a/cartridges/bm_imgix_pd/cartridge/experience/editors/imgix/imgixEditorTrigger.js
+++ b/cartridges/bm_imgix_pd/cartridge/experience/editors/imgix/imgixEditorTrigger.js
@@ -19,13 +19,15 @@ module.exports.init = function (editor) {
     source: "",
   };
 
+  // Store the message from the specified properties resource bundle in the
+  // accumulator under the given key.
   var reducer = function (acc, key) {
     acc.put(
       key,
       Resource.msg(
         key,
-        "experience.editors.imgix.imgixEditorTrigger",
-        defaults[key]
+        "experience.editors.imgix.imgixEditorTrigger", // bundleName
+        defaults[key] // defaultMessage
       )
     );
     return acc;


### PR DESCRIPTION
This commit adds a comment that explains how the `reducer` function makes use of the `Resource.msg()` API to store "bundle" attributes in a HahsMap.

For more information on this API read here: https://documentation.b2c.commercecloud.salesforce.com/DOC4/index.jsp?topic=%2Fcom.demandware.dochelp%2FDWAPI%2Fscriptapi%2Fhtml%2Fapi%2Fclass_dw_web_Resource.html