### PR TITLE
PE-1788 chore: remove z-index from stylesheets

### DIFF
--- a/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
@@ -51,7 +51,6 @@
     transition-property: all;
     transition-duration: 0.15s;
     transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94), linear;
-    z-index: 2;
   }
 }
 

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -26,7 +26,6 @@
   height: 40px;
   max-height: 400px;
   transition: height ease-out 0.2s;
-  z-index: 1;
 
   &.open {
     height: 500px;
@@ -40,7 +39,6 @@
   box-sizing: border-box;
   box-shadow: inset 0px 3px 0px #e8f0f4;
   border-radius: 3px;
-  z-index: 1;
   display: flex;
   height: 40px;
 }


### PR DESCRIPTION
Removing `z-index` use in response to SFCC feedback.

Tested changes on sandbox and all seemed to be OK. 

To test these changes yourself, pull down this branch,  run `yarn deploy`, and sync the cartridge CSS.

## Before this PR
`z-index` property was being used to style the source select dropdown

## After this PR
`z-index` property is no longer used to style the source select dropdown.