### PR TITLE
PE-1789 chore: change font related px to em values

### DIFF
--- a/frontend/src/components/Pagination/Pagination.module.scss
+++ b/frontend/src/components/Pagination/Pagination.module.scss
@@ -50,7 +50,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1em; /* 16px */
+  font-size: 1rem; /* 16px */
   color: #475f72;
   user-select: none;
   white-space: nowrap;

--- a/frontend/src/components/Pagination/Pagination.module.scss
+++ b/frontend/src/components/Pagination/Pagination.module.scss
@@ -50,7 +50,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
+  font-size: 1em; /* 16px */
   color: #475f72;
   user-select: none;
   white-space: nowrap;

--- a/frontend/src/components/SidebarApp.module.css
+++ b/frontend/src/components/SidebarApp.module.css
@@ -79,8 +79,8 @@
   font-family: Roboto;
   font-style: normal;
   font-weight: 500;
-  font-size: 0.8125em; /* 13px */
-  line-height: 1.1538461538461537em; /* 15px */
+  font-size: 0.813rem; /* 13px */
+  line-height: 1.15rem;
   text-transform: uppercase;
 
   color: #475f72;

--- a/frontend/src/components/SidebarApp.module.css
+++ b/frontend/src/components/SidebarApp.module.css
@@ -79,8 +79,8 @@
   font-family: Roboto;
   font-style: normal;
   font-weight: 500;
-  font-size: 13px;
-  line-height: 15px;
+  font-size: 0.8125em; /* 13px */
+  line-height: 1.1538461538461537em; /* 15px */
   text-transform: uppercase;
 
   color: #475f72;

--- a/frontend/src/components/Spinner/Spinner.module.scss
+++ b/frontend/src/components/Spinner/Spinner.module.scss
@@ -65,8 +65,8 @@ $spinner_padding: 6px;
 
 .label {
   margin-top: 12px;
-  font-size: 1.25em; /* 20 px */
-  line-height: 1.875em; /* 30 px */
+  font-size: 1.25em; /* 20px */
+  line-height: 1.88rem;
   text-align: center;
   color: #475f72;
 }

--- a/frontend/src/components/Spinner/Spinner.module.scss
+++ b/frontend/src/components/Spinner/Spinner.module.scss
@@ -65,8 +65,8 @@ $spinner_padding: 6px;
 
 .label {
   margin-top: 12px;
-  font-size: 20px;
-  line-height: 30px;
+  font-size: 1.25em; /* 20 px */
+  line-height: 1.875em; /* 30 px */
   text-align: center;
   color: #475f72;
 }

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
@@ -92,15 +92,15 @@
 
 .sourceName {
   color: #2b3944;
-  line-height: 1.5em; /* 24px */
-  margin-bottom: 8px;
+  line-height: 1.5rem;
+  margin-bottom: 0.5rem;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
 }
 .sourceType {
-  font-size: 0.875em; /* 14px */
-  line-height: 1.2307692307692308em; /* 16px */
+  font-size: 0.875rem; /* 14px */
+  line-height: 1rem;
   color: #475f72;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
@@ -92,15 +92,15 @@
 
 .sourceName {
   color: #2b3944;
-  line-height: 24px;
+  line-height: 1.5em; /* 24px */
   margin-bottom: 8px;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
 }
 .sourceType {
-  font-size: 14px;
-  line-height: 16px;
+  font-size: 0.875em; /* 14px */
+  line-height: 1.2307692307692308em; /* 16px */
   color: #475f72;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -78,8 +78,8 @@
   transition-property: transform, opacity;
   transition-duration: 0.2s;
   transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94), linear;
-  font-size: 14px;
-  line-height: 20px;
+  font-size: 0.875em; /* 14px */
+  line-height: 1.25em; /* 20px */
   color: #475f72;
 }
 .searchBaseInputField {
@@ -146,8 +146,8 @@
     color: white;
     font-style: normal;
     font-weight: 500;
-    font-size: 13px;
-    line-height: 15px;
+    font-size: 0.8125em; /* 13px */
+    line-height: 1.1538461538461537em; /* 15px */
     text-transform: uppercase;
     box-shadow: 0px 2px 0px #e3e7eb;
     & .searchIcon {
@@ -168,8 +168,8 @@
     color: white;
     font-style: normal;
     font-weight: 500;
-    font-size: 13px;
-    line-height: 15px;
+    font-size: 0.8125em; /* 13px */
+    line-height: 1.1538461538461537em; /* 15px */
     text-transform: uppercase;
     box-shadow: 0px 2px 0px #e3e7eb;
     margin-right: 8px;

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -78,8 +78,8 @@
   transition-property: transform, opacity;
   transition-duration: 0.2s;
   transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94), linear;
-  font-size: 0.875em; /* 14px */
-  line-height: 1.25em; /* 20px */
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   color: #475f72;
 }
 .searchBaseInputField {
@@ -146,8 +146,8 @@
     color: white;
     font-style: normal;
     font-weight: 500;
-    font-size: 0.8125em; /* 13px */
-    line-height: 1.1538461538461537em; /* 15px */
+    font-size: 0.813rem; /* 13px */
+    line-height: 0.94rem;
     text-transform: uppercase;
     box-shadow: 0px 2px 0px #e3e7eb;
     & .searchIcon {
@@ -168,8 +168,8 @@
     color: white;
     font-style: normal;
     font-weight: 500;
-    font-size: 0.8125em; /* 13px */
-    line-height: 1.1538461538461537em; /* 15px */
+    font-size: 0.813rem; /* 13px */
+    line-height: 0.94rem;
     text-transform: uppercase;
     box-shadow: 0px 2px 0px #e3e7eb;
     margin-right: 8px;

--- a/frontend/src/styles/Grid.css
+++ b/frontend/src/styles/Grid.css
@@ -74,8 +74,8 @@
   display: flex;
   justify-content: flex-end;
   flex: 0 1 auto;
-  font-size: 0.875em; /* 14px */
-  line-height: 2.2857142857142856em; /* 32px */
+  font-size: 0.875rem; /* 14px */
+  line-height: 2rem;
   color: #6c7f8e;
   font-style: normal;
   font-weight: normal;

--- a/frontend/src/styles/Grid.css
+++ b/frontend/src/styles/Grid.css
@@ -74,8 +74,8 @@
   display: flex;
   justify-content: flex-end;
   flex: 0 1 auto;
-  font-size: 14px;
-  line-height: 32px;
+  font-size: 0.875em; /* 14px */
+  line-height: 2.2857142857142856em; /* 32px */
   color: #6c7f8e;
   font-style: normal;
   font-weight: normal;


### PR DESCRIPTION
This commit changes font-related `px` values to corresponding `em` values. This was asked for in the SFCC cartridge review.

Most of these `em` values assume a "base font size" of `16px`.

Some of the `em` values are not 1:1 with their previous `px` values. This was done because the 1:1 `em` value threw things off. I suspect this is because the "base font-size" for the element in question is actually different from `16px`.

## Before/After this commit

> Images can be a tad misleading since they're not all the same size. You can however tell little if anything has changed.

before
![Screen Shot 2022-01-11 at 12 28 02 PM](https://user-images.githubusercontent.com/16711614/148992170-64226449-de01-4ae8-9a24-0152afe6bc35.png)

after
![Screen Shot 2022-01-11 at 12 27 15 PM](https://user-images.githubusercontent.com/16711614/148992184-f0b31045-2737-475f-8f1a-85689b793f4b.png)

