### PR TITLE
PE-1788 chore: remove z-index property usage from stylesheets

### DIFF
--- a/frontend/src/components/Pagination/Pagination.module.scss
+++ b/frontend/src/components/Pagination/Pagination.module.scss
@@ -50,7 +50,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
+  font-size: 1em; /* 16px */
   color: #475f72;
   user-select: none;
   white-space: nowrap;

--- a/frontend/src/components/SidebarApp.module.css
+++ b/frontend/src/components/SidebarApp.module.css
@@ -79,8 +79,8 @@
   font-family: Roboto;
   font-style: normal;
   font-weight: 500;
-  font-size: 13px;
-  line-height: 15px;
+  font-size: 0.8125em; /* 13px */
+  line-height: 1.1538461538461537em; /* 15px */
   text-transform: uppercase;
 
   color: #475f72;

--- a/frontend/src/components/Spinner/Spinner.module.scss
+++ b/frontend/src/components/Spinner/Spinner.module.scss
@@ -65,8 +65,8 @@ $spinner_padding: 6px;
 
 .label {
   margin-top: 12px;
-  font-size: 20px;
-  line-height: 30px;
+  font-size: 1.25em; /* 20 px */
+  line-height: 1.875em; /* 30 px */
   text-align: center;
   color: #475f72;
 }

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
@@ -92,15 +92,15 @@
 
 .sourceName {
   color: #2b3944;
-  line-height: 24px;
+  line-height: 1.5em; /* 24px */
   margin-bottom: 8px;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
 }
 .sourceType {
-  font-size: 14px;
-  line-height: 16px;
+  font-size: 0.875em; /* 14px */
+  line-height: 1.2307692307692308em; /* 16px */
   color: #475f72;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
@@ -51,7 +51,6 @@
     transition-property: all;
     transition-duration: 0.15s;
     transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94), linear;
-    z-index: 2;
   }
 }
 

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -26,7 +26,6 @@
   height: 40px;
   max-height: 400px;
   transition: height ease-out 0.2s;
-  z-index: 1;
 
   &.open {
     height: 500px;
@@ -40,7 +39,6 @@
   box-sizing: border-box;
   box-shadow: inset 0px 3px 0px #e8f0f4;
   border-radius: 3px;
-  z-index: 1;
   display: flex;
   height: 40px;
 }

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -78,8 +78,8 @@
   transition-property: transform, opacity;
   transition-duration: 0.2s;
   transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94), linear;
-  font-size: 14px;
-  line-height: 20px;
+  font-size: 0.875em; /* 14px */
+  line-height: 1.25em; /* 20px */
   color: #475f72;
 }
 .searchBaseInputField {
@@ -146,8 +146,8 @@
     color: white;
     font-style: normal;
     font-weight: 500;
-    font-size: 13px;
-    line-height: 15px;
+    font-size: 0.8125em; /* 13px */
+    line-height: 1.1538461538461537em; /* 15px */
     text-transform: uppercase;
     box-shadow: 0px 2px 0px #e3e7eb;
     & .searchIcon {
@@ -168,8 +168,8 @@
     color: white;
     font-style: normal;
     font-weight: 500;
-    font-size: 13px;
-    line-height: 15px;
+    font-size: 0.8125em; /* 13px */
+    line-height: 1.1538461538461537em; /* 15px */
     text-transform: uppercase;
     box-shadow: 0px 2px 0px #e3e7eb;
     margin-right: 8px;

--- a/frontend/src/styles/Grid.css
+++ b/frontend/src/styles/Grid.css
@@ -58,7 +58,8 @@
 }
 
 .ix-grid-item-image {
-  position: relative;
+  /* position: relative; */
+  position: static;
   overflow: hidden;
   height: 180px;
 }
@@ -82,20 +83,14 @@
   /* This supports the "ellipsis" behaviour to ensure that the filename stays on
    * one line */
   white-space: nowrap;
-  position: relative;
+  /* position: relative; */
+  position: static;
   padding: 6px 10px;
   margin: 0px;
-
   text-align: center;
-}
-
-.ix-grid-item-filename:before {
-  content: " ";
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  width: 20px;
-  background: linear-gradient(90deg, #fff 25%, #fff);
-  background: linear-gradient(90deg, #fff 25%, hsla(0, 0%, 100%, 0));
+  /* place gradient over start of filename to fade out text */
+  background-image: linear-gradient(270deg, #000000 57%, rgba(0, 0, 0, 0));
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 }

--- a/frontend/src/styles/Grid.css
+++ b/frontend/src/styles/Grid.css
@@ -74,8 +74,8 @@
   display: flex;
   justify-content: flex-end;
   flex: 0 1 auto;
-  font-size: 14px;
-  line-height: 32px;
+  font-size: 0.875em; /* 14px */
+  line-height: 2.2857142857142856em; /* 32px */
   color: #6c7f8e;
   font-style: normal;
   font-weight: normal;


### PR DESCRIPTION
This PR addresses SFCC feedback that asked us not to use the `z-index` property.

Using the positioning behavior of HTML elements, we can achieve the same effect of the `z-index` property by modifying the position stack context of certain elements.

This commit changes the `position` context of the asset grid items so that they can be statically positioned, allowing for the source select dropdown to, when absolutely positioned, render above the asset grid items.

This also made it necessary to change the way that filenames were faded out. Previously, this was done using pseudo-elements and `position: absolute`. Because of the new position context, this was no longer possible.

Instead, this commit makes use of ` linear-gradient` for a `background-image`. We can then `clip` the `text` against this gradient, filling the overlap with the color `transparent`.

The drawback to this approach is cross-browser compatibility is limited. But in the absolute worst case, some users will not see faded-out filenames but still see the modal element stacked above the asset grid items.