### PR TITLE
chore: copy SF HTML and CSS to Storybook for extension development

### DIFF
--- a/frontend/src/index-extension.tsx
+++ b/frontend/src/index-extension.tsx
@@ -1,0 +1,26 @@
+declare const chrome: any;
+
+export const injectExtensionApp = () => {
+  const el = document.querySelector('[data-dw-tooltip="Product.imgixData"]');
+  console.log(`el`, el);
+  if (el) {
+    el.innerHTML = "Hello World (came from the Browser Extension)!";
+  }
+};
+
+export const runExtension = () => {
+  chrome.extension.sendMessage({}, function (response: any) {
+    var readyStateCheckInterval = setInterval(function () {
+      if (document.readyState === "complete") {
+        clearInterval(readyStateCheckInterval);
+
+        // ----------------------------------------------------------
+        // This part of the script triggers when page is done loading
+        console.log("Hello. This message was sent from scripts/inject.js");
+        // ----------------------------------------------------------
+
+        setTimeout(injectExtensionApp, 3000);
+      }
+    }, 10);
+  });
+};

--- a/frontend/src/stories/extension/products.module.scss
+++ b/frontend/src/stories/extension/products.module.scss
@@ -1,0 +1,50 @@
+/* Styles copied from SF */
+.tableHeader {
+  background-color: #eee;
+  color: #54585a;
+  font-weight: bold;
+  padding: 3px 5px;
+  white-space: nowrap;
+}
+.aldi {
+  border: 1px solid #dadada;
+}
+
+.top {
+  vertical-align: top;
+}
+.fielditem2 {
+  font-weight: bold;
+  color: #000;
+  padding: 6px;
+  vertical-align: top;
+  white-space: nowrap;
+  padding-top: 5px;
+}
+.tableDetail {
+  padding-right: 6px;
+  padding-left: 6px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+  height: 18px;
+}
+
+.tableDetail,
+.tableDetail td {
+  color: #000;
+}
+
+.textarea {
+  background-color: #fff !important;
+  background-image: none;
+  border: 1px solid #a5aeb5;
+  padding: 1px 0 2px 2px;
+  margin: 0;
+}
+
+.w100 {
+  width: 100%;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}

--- a/frontend/src/stories/extension/products.stories.tsx
+++ b/frontend/src/stories/extension/products.stories.tsx
@@ -1,0 +1,91 @@
+import { ComponentMeta } from "@storybook/react";
+import React from "react";
+import { injectExtensionApp } from "../../index-extension";
+import "../../styles/App.css";
+import styles from "./products.module.scss";
+
+export const SFImgixProductsSection = () => {
+  return (
+    <table cellPadding="0" cellSpacing="0" style={{ width: "100%" }}>
+      <tbody>
+        <tr>
+          <td
+            className={`${styles.tableHeader} ${styles.aldi}`}
+            colSpan={3}
+            width="100%"
+          >
+            imgix
+          </td>
+        </tr>
+        <tr>
+          {/* Here was an image with 0 height... so I just removed it */}
+          <td colSpan={3}></td>
+        </tr>
+        <tr>
+          <td className={styles.top}>
+            <table cellSpacing="0" cellPadding="0" width="100%">
+              <tbody>
+                <tr>
+                  <td className={styles.fielditem2} align="right">
+                    <span
+                      data-dw-attruuid="48576099ecdd41387849fbe603"
+                      data-dw-tooltip="Product.imgixData"
+                    >
+                      imgix Images
+                    </span>
+                    :
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+          <td width="100%">
+            <table cellSpacing="0" cellPadding="0" width="100%">
+              <tbody>
+                <tr>
+                  <td
+                    id="Meta48576099ecdd41387849fbe603_Container"
+                    className={styles.tableDetail}
+                    width="100%"
+                  >
+                    <textarea
+                      name="Meta48576099ecdd41387849fbe603"
+                      rows={10}
+                      className={`${styles.w100} ${styles.textarea}`}
+                    ></textarea>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  );
+};
+
+const NoExtensionTemplate = () => (
+  <div
+    style={{
+      width: "90%",
+      margin: "64px 5%",
+    }}
+  >
+    <SFImgixProductsSection />
+  </div>
+);
+
+export const NoExtension = NoExtensionTemplate.bind({});
+
+const WithExtensionTemplate = () => {
+  React.useLayoutEffect(() => {
+    injectExtensionApp();
+  }, []);
+  return <NoExtensionTemplate />;
+};
+export const WithExtension = WithExtensionTemplate.bind({});
+
+export default {
+  title: "Extension/Products Imgix Section",
+  component: SFImgixProductsSection,
+} as ComponentMeta<typeof SFImgixProductsSection>;


### PR DESCRIPTION
This allows us to develop the extension inside storybook, rather than inside Chrome the whole time.

![image](https://user-images.githubusercontent.com/615334/149362069-f55401a1-edfe-4411-9f3e-763be4e1a191.png)
