### PR TITLE
feat: pass data object to on-click handler

### DIFF
--- a/frontend/src/components/ProductImage/ProductImageContainer.tsx
+++ b/frontend/src/components/ProductImage/ProductImageContainer.tsx
@@ -6,7 +6,7 @@ import { Overlay } from "../layouts/Overlay";
 import styles from "./ProductImageContainer.module.scss";
 
 interface Props {
-  onOpenBreakoutClick: () => void;
+  onOpenBreakoutClick: (data: any) => void;
   value: IImgixCustomAttributeValue;
 }
 
@@ -27,7 +27,7 @@ export const ProductImageContainer = ({
   return (
     <div
       className={styles.imageWrapper}
-      onClick={onOpenBreakoutClick}
+      onClick={() => onOpenBreakoutClick(value)}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >

--- a/frontend/src/components/ProductPageImages.tsx
+++ b/frontend/src/components/ProductPageImages.tsx
@@ -7,7 +7,7 @@ import { ProductImageContainer } from "./ProductImage/ProductImageContainer";
 export interface ProductPageImagesProps {
   disabled: boolean;
   images: IImgixCustomAttributeValue[] | undefined;
-  onClick: () => void;
+  onClick: (data: any) => void;
 }
 
 export const ProductPageImages = ({
@@ -21,7 +21,7 @@ export const ProductPageImages = ({
         <AddButton
           disabled={disabled}
           label="ADD IMAGE"
-          onOpenBreakoutClick={onClick}
+          onOpenBreakoutClick={() => onClick(null)}
         />
       </div>
       <>

--- a/frontend/src/components/layouts/Modal.module.scss
+++ b/frontend/src/components/layouts/Modal.module.scss
@@ -1,0 +1,44 @@
+.backdrop {
+  align-items: center;
+  backdrop-filter: blur(10px);
+  background-color: rgba(51, 51, 51, 0.3);
+  display: flex;
+  justify-content: center;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  transition-delay: 200ms;
+  transition: all 100ms cubic-bezier(0.4, 0, 0.2, 1);
+  position: absolute;
+
+  & .modal-content {
+    transform: translateY(100px);
+    transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  &.active {
+    opacity: 1;
+    transition-delay: 0ms;
+    transition-duration: 250ms;
+
+    & .modal-content {
+      opacity: 1;
+      transform: translateY(0);
+      transition-delay: 150ms;
+      transition-duration: 350ms;
+    }
+  }
+}
+
+.content {
+  background-color: white;
+  border-radius: 2px;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+  box-sizing: border-box;
+  max-height: 80%;
+  max-width: 80%;
+  min-height: 50px;
+  min-width: 50px;
+  padding: 20px;
+}

--- a/frontend/src/components/layouts/Modal.tsx
+++ b/frontend/src/components/layouts/Modal.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import styles from "./Modal.module.scss";
+import Portal from "./Portal";
+
+interface ModalProps {
+  children: React.ReactNode | React.ReactNode[];
+  locked: boolean; // cant be closed by clicking outside if true
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function Modal({ children, locked, open, onClose }: ModalProps) {
+  const backdrop = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const { current } = backdrop;
+
+    const keyHandler = (e: KeyboardEvent) => e.key == "Escape" && onClose();
+
+    const clickHandler = (e: MouseEvent) =>
+      !locked && e.target === current && onClose();
+
+    if (current) {
+      current.addEventListener("click", clickHandler);
+      window.addEventListener("keyup", keyHandler);
+    }
+
+    if (open) {
+      window.setTimeout(() => {
+        const activeElement = document?.activeElement as HTMLElement;
+        if (activeElement) activeElement.blur();
+      }, 10);
+    }
+
+    return () => {
+      if (current) {
+        current.removeEventListener("click", clickHandler);
+      }
+
+      window.removeEventListener("keyup", keyHandler);
+    };
+  }, [open, locked, onClose]);
+
+  console.log("[imgix] Modal", open ? "opened" : "closed");
+
+  return (
+    <>
+      {open && (
+        <Portal className="modalPortal">
+          <div
+            ref={backdrop}
+            className={`${styles.backdrop} ${open && "active"}`}
+          >
+            <div className={`${styles.content} modal-content`}>{children}</div>
+          </div>
+        </Portal>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/layouts/Modal.tsx
+++ b/frontend/src/components/layouts/Modal.tsx
@@ -9,7 +9,7 @@ interface ModalProps {
   onClose: () => void;
 }
 
-export default function Modal({ children, locked, open, onClose }: ModalProps) {
+export function Modal({ children, locked, open, onClose }: ModalProps) {
   const backdrop = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
@@ -46,12 +46,14 @@ export default function Modal({ children, locked, open, onClose }: ModalProps) {
   return (
     <>
       {open && (
-        <Portal className="modalPortal">
+        <Portal>
           <div
             ref={backdrop}
-            className={`${styles.backdrop} ${open && "active"}`}
+            className={`${styles.backdrop} ${open && styles.active}`}
           >
-            <div className={`${styles.content} modal-content`}>{children}</div>
+            <div className={`${styles.content} ${styles["modal-content"]}`}>
+              {children}
+            </div>
           </div>
         </Portal>
       )}

--- a/frontend/src/stories/Modal.stories.tsx
+++ b/frontend/src/stories/Modal.stories.tsx
@@ -1,0 +1,39 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+import { Modal as _Modal } from "../components/layouts/Modal";
+
+export default {
+  title: "Style/Modal",
+  component: _Modal,
+  parameters: {
+    layout: "centered",
+  },
+} as ComponentMeta<typeof _Modal>;
+
+const Template: ComponentStory<typeof _Modal> = (args) => {
+  const [open, setOpen] = React.useState(false);
+  const onClose = () => {
+    console.log("[imgix] Modal closed");
+    setOpen(false);
+  };
+  const onOpen = (data: any) => {
+    console.log("[imgix] Modal opened");
+    setOpen(true);
+  };
+
+  return (
+    <>
+      <_Modal {...{ ...args, open, onClose }}>
+        <div>
+          <h1>I'm in a modal!</h1>
+          <h2>Hit escape or click outside to close.</h2>
+          <h2>Set `locked` to `true` to disable click-outside.</h2>
+        </div>
+      </_Modal>
+      <button onClick={onOpen}>Open modal</button>
+    </>
+  );
+};
+
+export const Modal = Template.bind({});
+Modal.args = {};


### PR DESCRIPTION
This PR allows for the `ProductImageContainer.tsx` `onClick` handler to accept a `data` object. This object can then be passed onto a different component in the future.

This was done to try and share selection information between the images container and an upcoming IM modal in the following PR.