### PR TITLE
chore: refactor product images tests and model implementation to be more logical and fix some bugs"

### DIFF
--- a/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.js
+++ b/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.js
@@ -19,25 +19,105 @@ function Images(product, imageConfig) {
   const imgixDefaultParams =
     currentSite.getCustomPreferenceValue("imgixProductDefaultParams") || "";
 
-  if (isBaseURLSet) {
-    // Here we transform the URL
-    let imgixJsonImages = null;
-
+  const imgixCustomAttributeData = (() => {
     if (product instanceof ProductVariationModel) {
       // Get imgix data custom attribute from selected variant or master product
       const productData = product.selectedVariant || product.master;
-      imgixJsonImages =
+      return (
         productData &&
         productData.custom &&
         productData.custom.imgixData &&
-        JSON.parse(productData.custom.imgixData);
+        JSON.parse(productData.custom.imgixData)
+      );
     } else if (product instanceof Variant || product instanceof Product) {
-      imgixJsonImages =
+      return (
         product.custom &&
         product.custom.imgixData &&
-        JSON.parse(product.custom.imgixData);
+        JSON.parse(product.custom.imgixData)
+      );
     }
+    return undefined;
+  })();
 
+  /* The next section operates in one of three modes:
+   * 1. if custom attribute data exists, use that to render the images (as this
+   *    overrides the built-in SF data)
+   * 2. otherwise, if the imgixBaseURL is set, use that to render the images
+   * 3. fallback to the built-in SF data
+   */
+
+  if (imgixCustomAttributeData) {
+    imageConfig.types.forEach(function (type) {
+      var images = product.getImages(type);
+      var result = {};
+
+      if (imageConfig.quantity === "single") {
+        var firstImage = collections.first(images);
+        if (firstImage) {
+          let imageUrl =
+            imgixCustomAttributeData.images.primary.src +
+            (imgixDefaultParams ? "?" + imgixDefaultParams : "");
+          // TODO: update sourceWidth adding
+          imageUrl = appendSourceWidth(
+            imageUrl,
+            imgixCustomAttributeData.images.primary.sourceWidth
+          );
+
+          result = [
+            {
+              alt: firstImage.alt,
+              url: imageUrl,
+              title: firstImage.title,
+              index: "0",
+              absURL: imageUrl,
+            },
+          ];
+        }
+      } else {
+        result = collections.map(images, function (image, index) {
+          let imageUrl;
+          if (index === 0) {
+            // TODO: add tests for default params
+            imageUrl =
+              imgixCustomAttributeData.images.primary.src +
+              (imgixDefaultParams ? "?" + imgixDefaultParams : "");
+            // TODO: update sourceWidth adding
+            imageUrl = appendSourceWidth(
+              imageUrl,
+              imgixCustomAttributeData.images.primary.sourceWidth
+            );
+          } else {
+            const imageIndex = index - 1;
+            if (
+              imageIndex < imgixCustomAttributeData.images.alternatives.length
+            ) {
+              // TODO: add tests for default params
+              imageUrl =
+                imgixCustomAttributeData.images.alternatives[imageIndex].src +
+                (isBaseURLSet && imgixDefaultParams
+                  ? "?" + imgixDefaultParams
+                  : "");
+              // TODO: update sourceWidth adding
+              imageUrl = appendSourceWidth(
+                imageUrl,
+                imgixCustomAttributeData.images.alternatives[imageIndex]
+                  .sourceWidth
+              );
+            }
+          }
+
+          return {
+            alt: image.alt,
+            url: imageUrl,
+            index: index.toString(),
+            title: image.title,
+            absURL: imageUrl,
+          };
+        });
+      }
+      this[type] = result;
+    }, this);
+  } else if (isBaseURLSet) {
     imageConfig.types.forEach(function (type) {
       var images = product.getImages(type);
       var result = {};
@@ -51,17 +131,6 @@ function Images(product, imageConfig) {
             (isBaseURLSet && imgixDefaultParams
               ? "?" + imgixDefaultParams
               : "");
-          if (imgixJsonImages) {
-            // TODO: add tests for default params
-            imageUrl =
-              imgixJsonImages.images.primary.src +
-              (imgixDefaultParams ? "?" + imgixDefaultParams : "");
-            // TODO: update sourceWidth adding
-            imageUrl = appendSourceWidth(
-              imageUrl,
-              imgixJsonImages.images.primary.sourceWidth
-            );
-          }
 
           result = [
             {
@@ -69,7 +138,7 @@ function Images(product, imageConfig) {
               url: imageUrl,
               title: firstImage.title,
               index: "0",
-              absURL: firstImage.absURL.toString(),
+              absURL: imageUrl,
             },
           ];
         }
@@ -81,43 +150,13 @@ function Images(product, imageConfig) {
             (isBaseURLSet && imgixDefaultParams
               ? "?" + imgixDefaultParams
               : "");
-          if (imgixJsonImages) {
-            if (index === 0) {
-              // TODO: add tests for default params
-              imageUrl =
-                imgixJsonImages.images.primary.src +
-                (isBaseURLSet && imgixDefaultParams
-                  ? "?" + imgixDefaultParams
-                  : "");
-              // TODO: update sourceWidth adding
-              imageUrl = appendSourceWidth(
-                imageUrl,
-                imgixJsonImages.images.primary.sourceWidth
-              );
-            } else {
-              const imageIndex = index - 1;
-              if (imageIndex < imgixJsonImages.images.alternatives.length) {
-                // TODO: add tests for default params
-                imageUrl =
-                  imgixJsonImages.images.alternatives[imageIndex].src +
-                  (isBaseURLSet && imgixDefaultParams
-                    ? "?" + imgixDefaultParams
-                    : "");
-                // TODO: update sourceWidth adding
-                imageUrl = appendSourceWidth(
-                  imageUrl,
-                  imgixJsonImages.images.alternatives[imageIndex].sourceWidth
-                );
-              }
-            }
-          }
 
           return {
             alt: image.alt,
             url: imageUrl,
             index: index.toString(),
             title: image.title,
-            absURL: image.absURL.toString(),
+            absURL: imageUrl,
           };
         });
       }
@@ -146,7 +185,7 @@ function Images(product, imageConfig) {
         result = collections.map(images, function (image, index) {
           return {
             alt: image.alt,
-            url: firstImage.URL.toString(),
+            url: image.URL.toString(),
             index: index.toString(),
             title: image.title,
             absURL: image.absURL.toString(),


### PR DESCRIPTION
This PR addresses some inconsistencies in the testing and product images implementation

## Before

- Tests: hard to distinguish in testing data between SF data and imgix attribute data
- Tests: was hard to distinguish the context behind tests (whether custom attribute data was set, whether imgix base URL preference was set)
- Tests: not all edge cases were tested (e.g. requesting multiple images when no imgix base URL preference was set caused a `TypeError`)
- Product Images Model: there was a bug where requesting multiple images when no imgix base URL preference was set would cause `TypeError`
- Product Images Model: the organisation made it difficult to reason about the mode of operation, when there were distinctly three modes of operation: using custom attribute data, using SF data w/ imgix base URL preference set, and falling back to SF data when no imgix base URL preference was set
- Product Images Model: `absURL` data returned was not modified, causing potentially inconsistencies and bugs downstream depending on usage of `url` and `absURL`

## After

- Tests: SF data encoded with `sf_` prefix, and imgix attribute data prefixed with `imgix_`. Also the imgix domain for custom attribute data was changed to `customImgixURL`. This allows the tests to better test that the data is being pulled from the right place. E.g. before the implementation could have pulled the imgix domain from the custom attribute, but the path from the SF data, and the test would still would have passed
- Tests: more edge cases were added
- Tests: some stubbed tests were added to be implemented later
- Product Image Model: requesting multiple images when no imgix base URL preference is set no longer causes an error
- Product Image Model: refactored to show distinct differences between three modes of operation
- Product Image Model: `absURL` now points to imgix url, when it exists. **Edit:** confirmed this with Hasan and this is correct behaviour 