### PR TITLE
fix: add min-height to asset container

### DIFF
--- a/frontend/src/components/AssetBrowser/AssetBrowser.module.scss
+++ b/frontend/src/components/AssetBrowser/AssetBrowser.module.scss
@@ -4,6 +4,7 @@
   padding-bottom: 16px;
   display: flex;
   flex-direction: column;
+  min-height: 730px;
 }
 .assetTitleBarContainer {
   background-color: white;


### PR DESCRIPTION
This commit adds a `min-height` of `730px` to the `.assetBrowser` class. This fixes an issue where the container would not take up the entire height of the modal.

This will mean that on smaller windows/devices the frame will be scrollable.

Part of the problem is a script SFCC runs in the background that listens for window and or frame resizing. It impedes us from "reactively" sizing the container as the iframe w/h can be changed at any time by the SFCC background script. Moreover, trying to get the `document.offsetHeight` or similar techniques for getting the window size have proven unreliable. Probably at least in part due to that background SFCC script.

## Video 📹 

### before
https://user-images.githubusercontent.com/16711614/150380148-f52826e6-9b0a-4dae-a83f-65cd6345b952.mov

"mobile"/smaller screens

https://user-images.githubusercontent.com/16711614/150380652-0dc3729c-2fad-4702-9643-5203c79173b7.mov


### after
https://user-images.githubusercontent.com/16711614/150380198-87f8ddab-6174-48ad-8e49-d91b66deedae.mov

"mobile"/smaller screens

https://user-images.githubusercontent.com/16711614/150380679-7be1e9e6-036d-434d-8f1a-24d508e72606.mov



