### PR TITLE
feat: disable proxying product images when custom preference is disabled

### DIFF
--- a/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.js
+++ b/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.js
@@ -18,6 +18,9 @@ function Images(product, imageConfig) {
   const isBaseURLSet = imgixBaseURL.trim().length > 0;
   const imgixDefaultParams =
     currentSite.getCustomPreferenceValue("imgixProductDefaultParams") || "";
+  const imgixEnableProductImageProxy = currentSite.getCustomPreferenceValue(
+    "imgixEnableProductImageProxy"
+  );
 
   const imgixCustomAttributeData = (() => {
     if (product instanceof ProductVariationModel) {
@@ -46,7 +49,9 @@ function Images(product, imageConfig) {
    * 3. fallback to the built-in SF data
    */
 
-  if (imgixCustomAttributeData) {
+  if (imgixEnableProductImageProxy && imgixCustomAttributeData) {
+    // 1. custom attribute data exists
+
     imageConfig.types.forEach(function (type) {
       var images = product.getImages(type);
       var result = {};
@@ -117,7 +122,9 @@ function Images(product, imageConfig) {
       }
       this[type] = result;
     }, this);
-  } else if (isBaseURLSet) {
+  } else if (imgixEnableProductImageProxy && isBaseURLSet) {
+    // 2. if the imgixBaseURL is set, use that to render the images
+
     imageConfig.types.forEach(function (type) {
       var images = product.getImages(type);
       var result = {};
@@ -163,7 +170,8 @@ function Images(product, imageConfig) {
       this[type] = result;
     }, this);
   } else {
-    // Here we just pass through values
+    // 3. fallback to the built-in SF data. Here we just pass through values.
+
     imageConfig.types.forEach(function (type) {
       var images = product.getImages(type);
       var result = {};

--- a/test/unit/int_imgix_products_sfra/models/product/productImages.js
+++ b/test/unit/int_imgix_products_sfra/models/product/productImages.js
@@ -459,7 +459,7 @@ describe("ProductImages model", function () {
       it("original size image");
     });
 
-    describe("should not proxy images when feature is disabled", () => {
+    describe("should not proxy url or absURL when feature is disabled", () => {
       it("when querying single image from a product with a custom attribute", () => {
         imgixEnableProductImageProxyValue = false;
 
@@ -468,8 +468,8 @@ describe("ProductImages model", function () {
           quantity: "single",
         });
 
-        assert.notInclude(singleImage.large[0].url, "customImgixURL");
-        assert.include(singleImage.large[0].url, "sf_first_image_url");
+        assert.equal(singleImage.large[0].url, "/sf_first_image_url");
+        assert.equal(singleImage.large[0].absURL, "path/sf_first_image_url");
 
         imgixEnableProductImageProxyValue = true;
       });
@@ -482,16 +482,48 @@ describe("ProductImages model", function () {
           quantity: "*",
         });
 
-        assert.notInclude(multipleImages.large[0].url, "customImgixURL");
-        assert.include(multipleImages.large[0].url, "sf_first_image_url");
-
-        assert.notInclude(multipleImages.large[1].url, "customImgixURL");
-        assert.include(multipleImages.large[1].url, "sf_second_image_url");
+        assert.equal(multipleImages.large[0].url, "/sf_first_image_url");
+        assert.equal(multipleImages.large[0].absURL, "path/sf_first_image_url");
+        assert.equal(multipleImages.large[1].url, "/sf_second_image_url");
+        assert.equal(
+          multipleImages.large[1].absURL,
+          "path/sf_second_image_url"
+        );
 
         imgixEnableProductImageProxyValue = true;
       });
 
-      it("pass-through images");
+      it("when querying single pass-through image", () => {
+        imgixEnableProductImageProxyValue = false;
+
+        const singleImage = new ProductImages(new Product(), {
+          types: ["large"],
+          quantity: "single",
+        });
+
+        assert.equal(singleImage.large[0].url, "/sf_first_image_url");
+        assert.equal(singleImage.large[0].absURL, "path/sf_first_image_url");
+
+        imgixEnableProductImageProxyValue = true;
+      });
+      it("when querying multiple pass-through images", () => {
+        imgixEnableProductImageProxyValue = false;
+
+        const multipleImages = new ProductImages(new Product(), {
+          types: ["large"],
+          quantity: "*",
+        });
+
+        assert.equal(multipleImages.large[0].url, "/sf_first_image_url");
+        assert.equal(multipleImages.large[0].absURL, "path/sf_first_image_url");
+        assert.equal(multipleImages.large[1].url, "/sf_second_image_url");
+        assert.equal(
+          multipleImages.large[1].absURL,
+          "path/sf_second_image_url"
+        );
+
+        imgixEnableProductImageProxyValue = true;
+      });
     });
   });
 });


### PR DESCRIPTION
This PR implements a part of the Salesforce required feedback to allow the product image proxying to be disabled. When the custom preference is set to "false" or "disabled", then the integration will fall back to passing through the images stored in SF, without modification.
