### PR TITLE
chore: simplify product images custom attribute implementation

### DIFF
--- a/test/unit/int_imgix_products_sfra/models/product/productImages.js
+++ b/test/unit/int_imgix_products_sfra/models/product/productImages.js
@@ -16,8 +16,8 @@ var toProductMock = require("../../../../util");
  */
 var images = new ArrayList([
   {
-    alt: "First Image",
-    title: "First Image",
+    alt: "First Image alt",
+    title: "First Image title",
     index: "0",
     URL: {
       toString: function () {
@@ -31,8 +31,8 @@ var images = new ArrayList([
     },
   },
   {
-    alt: "Second Image",
-    title: "Second Image",
+    alt: "Second Image alt",
+    title: "Second Image title",
     index: "1",
     URL: {
       toString: function () {
@@ -285,9 +285,9 @@ describe("ProductImages model", function () {
           quantity: "*",
         });
         assert.equal(images.small.length, 2);
-        assert.equal(images.small[0].alt, "First Image");
+        assert.equal(images.small[0].alt, "First Image alt");
         assert.equal(images.small[0].index, "0");
-        assert.equal(images.small[0].title, "First Image");
+        assert.equal(images.small[0].title, "First Image title");
         assert.equal(images.small[0].url, "imgixBaseURL/sf_first_image_url");
         assert.equal(images.small[0].absURL, "imgixBaseURL/sf_first_image_url");
         assert.equal(images.small[1].url, "imgixBaseURL/sf_second_image_url");
@@ -304,8 +304,8 @@ describe("ProductImages model", function () {
           quantity: "single",
         });
         assert.equal(images.small.length, 1);
-        assert.equal(images.small[0].alt, "First Image");
-        assert.equal(images.small[0].title, "First Image");
+        assert.equal(images.small[0].alt, "First Image alt");
+        assert.equal(images.small[0].title, "First Image title");
         assert.equal(images.small[0].index, "0");
         assert.equal(images.small[0].url, "imgixBaseURL/sf_first_image_url");
         assert.equal(images.small[0].absURL, "imgixBaseURL/sf_first_image_url");
@@ -324,8 +324,8 @@ describe("ProductImages model", function () {
           quantity: "*",
         });
         assert.equal(images.small.length, 2);
-        assert.equal(images.small[0].alt, "First Image");
-        assert.equal(images.small[0].title, "First Image");
+        assert.equal(images.small[0].alt, "First Image alt");
+        assert.equal(images.small[0].title, "First Image title");
         assert.equal(images.small[0].index, "0");
         assert.equal(images.small[0].url, "/sf_first_image_url");
         assert.equal(images.small[0].absURL, "path/sf_first_image_url");
@@ -348,8 +348,8 @@ describe("ProductImages model", function () {
           quantity: "single",
         });
         assert.equal(images.small.length, 1);
-        assert.equal(images.small[0].alt, "First Image");
-        assert.equal(images.small[0].title, "First Image");
+        assert.equal(images.small[0].alt, "First Image alt");
+        assert.equal(images.small[0].title, "First Image title");
         assert.equal(images.small[0].index, "0");
         assert.equal(images.small[0].url, "/sf_first_image_url");
 

--- a/test/unit/int_imgix_products_sfra/models/product/productImages.js
+++ b/test/unit/int_imgix_products_sfra/models/product/productImages.js
@@ -48,7 +48,7 @@ var images = new ArrayList([
 ]);
 var customData = {
   imgixData:
-    '{"images": {"primary": {"src": "customImgixURL/imgix_first_image_url"},"alternatives": [{"src": "customImgixURL/imgix_second_image_url","sourceWidth": 3000}]}}',
+    '{"images": {"primary": {"src": "customImgixURL/imgix_first_image_url", "title": "First Image title", "alt": "First Image alt"},"alternatives": [{"src": "customImgixURL/imgix_second_image_url","sourceWidth": 3000}]}}',
 };
 
 var productMock = {
@@ -80,6 +80,12 @@ class Product {
   }
 }
 class Variant extends Product {}
+
+class Logger {
+  static info(...args) {
+    console.log(...args);
+  }
+}
 
 describe("ProductImages model", function () {
   let imgixBaseURLPreferenceValue = "imgixBaseURL";
@@ -134,6 +140,7 @@ describe("ProductImages model", function () {
       "dw/catalog/ProductVariationModel": ProductVariationModel,
       "dw/catalog/Product": Product,
       "dw/catalog/Variant": Variant,
+      "dw/catalog/Logger": Logger,
     }
   );
 
@@ -145,9 +152,9 @@ describe("ProductImages model", function () {
         quantity: "*",
       });
       assert.equal(images.small.length, 2);
-      assert.equal(images.small[0].alt, "First Image");
+      assert.equal(images.small[0].alt, "First Image alt");
       assert.equal(images.small[0].index, "0");
-      assert.equal(images.small[0].title, "First Image");
+      assert.equal(images.small[0].title, "First Image title");
       assert.equal(images.small[0].url, "customImgixURL/imgix_first_image_url");
       assert.equal(
         images.small[0].absURL,
@@ -155,12 +162,12 @@ describe("ProductImages model", function () {
       );
       assert.equal(
         images.small[1].url,
-        "customImgixURL/imgix_second_image_url?sourceWidth=3000"
+        "customImgixURL/imgix_second_image_url"
       );
       // TODO: check if we should be modifying path
       assert.equal(
         images.small[1].absURL,
-        "customImgixURL/imgix_second_image_url?sourceWidth=3000"
+        "customImgixURL/imgix_second_image_url"
       );
       assert.equal(images.small[1].index, "1");
     });
@@ -172,8 +179,8 @@ describe("ProductImages model", function () {
         quantity: "single",
       });
       assert.equal(images.small.length, 1);
-      assert.equal(images.small[0].alt, "First Image");
-      assert.equal(images.small[0].title, "First Image");
+      assert.equal(images.small[0].alt, "First Image alt");
+      assert.equal(images.small[0].title, "First Image title");
       assert.equal(images.small[0].index, "0");
       assert.equal(images.small[0].url, "customImgixURL/imgix_first_image_url");
       assert.equal(
@@ -188,9 +195,9 @@ describe("ProductImages model", function () {
         quantity: "*",
       });
       assert.equal(images.small.length, 2);
-      assert.equal(images.small[0].alt, "First Image");
+      assert.equal(images.small[0].alt, "First Image alt");
       assert.equal(images.small[0].index, "0");
-      assert.equal(images.small[0].title, "First Image");
+      assert.equal(images.small[0].title, "First Image title");
       assert.equal(images.small[0].url, "customImgixURL/imgix_first_image_url");
       assert.equal(
         images.small[0].absURL,
@@ -198,12 +205,12 @@ describe("ProductImages model", function () {
       );
       assert.equal(
         images.small[1].url,
-        "customImgixURL/imgix_second_image_url?sourceWidth=3000"
+        "customImgixURL/imgix_second_image_url"
       );
 
       assert.equal(
         images.small[1].absURL,
-        "customImgixURL/imgix_second_image_url?sourceWidth=3000"
+        "customImgixURL/imgix_second_image_url"
       );
       assert.equal(images.small[1].index, "1");
     });
@@ -214,9 +221,9 @@ describe("ProductImages model", function () {
         quantity: "*",
       });
       assert.equal(images.small.length, 2);
-      assert.equal(images.small[0].alt, "First Image");
+      assert.equal(images.small[0].alt, "First Image alt");
       assert.equal(images.small[0].index, "0");
-      assert.equal(images.small[0].title, "First Image");
+      assert.equal(images.small[0].title, "First Image title");
       assert.equal(images.small[0].url, "customImgixURL/imgix_first_image_url");
       assert.equal(
         images.small[0].absURL,
@@ -224,12 +231,12 @@ describe("ProductImages model", function () {
       );
       assert.equal(
         images.small[1].url,
-        "customImgixURL/imgix_second_image_url?sourceWidth=3000"
+        "customImgixURL/imgix_second_image_url"
       );
 
       assert.equal(
         images.small[1].absURL,
-        "customImgixURL/imgix_second_image_url?sourceWidth=3000"
+        "customImgixURL/imgix_second_image_url"
       );
       assert.equal(images.small[1].index, "1");
     });
@@ -240,8 +247,8 @@ describe("ProductImages model", function () {
         quantity: "single",
       });
       assert.equal(images.small.length, 1);
-      assert.equal(images.small[0].alt, "First Image");
-      assert.equal(images.small[0].title, "First Image");
+      assert.equal(images.small[0].alt, "First Image alt");
+      assert.equal(images.small[0].title, "First Image title");
       assert.equal(images.small[0].index, "0");
       assert.equal(images.small[0].url, "customImgixURL/imgix_first_image_url");
       assert.equal(
@@ -256,8 +263,8 @@ describe("ProductImages model", function () {
         quantity: "single",
       });
       assert.equal(images.small.length, 1);
-      assert.equal(images.small[0].alt, "First Image");
-      assert.equal(images.small[0].title, "First Image");
+      assert.equal(images.small[0].alt, "First Image alt");
+      assert.equal(images.small[0].title, "First Image title");
       assert.equal(images.small[0].index, "0");
       assert.equal(images.small[0].url, "customImgixURL/imgix_first_image_url");
       assert.equal(


### PR DESCRIPTION
## Before

- The SF images images were being iterated over, and only the URL was being replaced by the custom attribute data. This could (and probably would) have led to scenarios where the data was incorrect/out-of-sync. For example, if there were more or less SF images than custom attribute images, some images could have no url set (in the case of there being more SF images), or the image would not be displayed (if SF had less images). Furthermore, if the order of the images was different, the title and alt would associated with the wrong image.
- `sourceWidth` was being added to the imgix URL, which is incorrect

## After
- The code iterates solely over the custom attribute images, ensuring that it can no longer be out of sync
- `sourceWidth` is no longer added to the imgix URL
- The code has been simplified
- The tests are more robust, having different values for "title" and "alt" assertions, reducing the possibility for incorrectness 
