### PR TITLE
feat!: add preference to disable page designer

### DIFF
--- a/cartridges/bm_imgix_pd/cartridge/experience/editors/imgix/imgixEditorTrigger.js
+++ b/cartridges/bm_imgix_pd/cartridge/experience/editors/imgix/imgixEditorTrigger.js
@@ -47,8 +47,9 @@ module.exports.init = function (editor) {
 
   // Create a configuration for a custom editor to be displayed in a modal breakout dialog (breakout editor)
   var breakoutEditorConfig = new HashMap();
-  imgixApi["apiKey"] = currentSite.getCustomPreferenceValue(
-    "imgixApiKey"
+  imgixApi["apiKey"] = currentSite.getCustomPreferenceValue("imgixApiKey");
+  imgixApi["enabled"] = currentSite.getCustomPreferenceValue(
+    "imgixEnablePageDesigner"
   );
 
   breakoutEditorConfig.put("localization", localization);

--- a/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
+++ b/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
@@ -12,6 +12,16 @@ module.exports.render = function (context, modelIn) {
   ImgixLogger.info(
     "************************** imgix Image Component Start Render"
   );
+  const isEnabled = Site.getCurrent().getCustomPreferenceValue(
+    "imgixEnablePageDesigner"
+  );
+
+  if (!isEnabled) {
+    ImgixLogger.info(
+      "************************** imgix Image Component Render Aborted"
+    );
+    return;
+  }
 
   var model = modelIn || new HashMap();
   var content = context.content;

--- a/frontend/src/components/SidebarApp.module.scss
+++ b/frontend/src/components/SidebarApp.module.scss
@@ -139,3 +139,18 @@
   height: 16px;
   width: 16px;
 }
+
+.disabled {
+  * {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  .imageCaptionText {
+    opacity: 1;
+    padding-left: 5px;
+    display: inline-block;
+    text-overflow: unset;
+    overflow: unset;
+  }
+}

--- a/frontend/src/components/SidebarApp.tsx
+++ b/frontend/src/components/SidebarApp.tsx
@@ -5,15 +5,43 @@ import { IImgixCustomAttributeValue } from "../types/imgixSF";
 import { AddSvg } from "./icons/AddSvg";
 import { RefreshSvg } from "./icons/RefreshSvg";
 import { TrashcanSvg } from "./icons/TrashcanSvg";
-import styles from "./SidebarApp.module.css";
+import styles from "./SidebarApp.module.scss";
 
 export type ISidebarAppProps = {
   onOpenBreakoutClick: () => void;
   onClear: () => void;
+  disabled: boolean;
   value: IImgixCustomAttributeValue | undefined;
 };
 
-export function App({ onOpenBreakoutClick, onClear, value }: ISidebarAppProps) {
+export function App({
+  onOpenBreakoutClick,
+  onClear,
+  disabled,
+  value,
+}: ISidebarAppProps) {
+  if (disabled) {
+    // return a placeholder telling the user to enable the component
+    return (
+      <div className={styles.disabled}>
+        <div className={`${styles.imageWrapper} ${styles.disabled}`}></div>
+        <div className={styles.imageCaption}>
+          <span className={styles.imageCaptionText}>
+            imgix integration disabled. <br />
+          </span>
+        </div>
+        <div className={styles.imageCaption}>
+          <span className={styles.imageCaptionText}>
+            <span className={styles.imageCaptionText}>
+              To re-enable, go to custom preferences and <br />
+              set `imgixEnablePageDesigner` to `true`.
+            </span>
+          </span>
+        </div>
+        <div className={styles.hr} />
+      </div>
+    );
+  }
   return (
     <div className="App">
       <header className="App-header">

--- a/frontend/src/index-sidebar.tsx
+++ b/frontend/src/index-sidebar.tsx
@@ -12,6 +12,10 @@ declare const subscribe: SandboxSubscribe<
 
 export const createSidebarApp = () => {
   let localization: any;
+  let imgixApi: {
+    apiKey?: string;
+    enabled?: boolean;
+  };
 
   subscribe(
     "sfcc:ready",
@@ -24,7 +28,7 @@ export const createSidebarApp = () => {
       displayLocale,
     }: any) => {
       // Extract `localization` data from `config`
-      ({ localization = {} } = config);
+      ({ localization = {}, imgixApi = {} } = config);
 
       let state: {
         value: IImgixCustomAttributeValue | {};
@@ -95,6 +99,7 @@ export const createSidebarApp = () => {
               onOpenBreakoutClick={handleBreakoutOpen}
               onClear={handleValueClear}
               value={safeValue}
+              disabled={imgixApi.enabled === false}
             />
           </React.StrictMode>,
           rootEditorElement


### PR DESCRIPTION
This PR makes it so that settings the `imgixEnablePageDesigner` to `No`, or `false`, will keep the imgix PD component and ISML templates from rendering on the page.

This PR also changes the `SidebarApp` CSS module to be a SASS module.

## Screenshots 🖼️ 
Markup when disabled
![disabled-pd-markup](https://user-images.githubusercontent.com/16711614/151472443-c1a0bf08-c442-4eec-862e-fde22a3bab36.jpg)

Sidebar when disabled
![imgix-pd-disabled](https://user-images.githubusercontent.com/16711614/151472436-827c655c-d8a8-4e5c-813d-95dfa783ee1b.jpg)

