### PR TITLE
feat(search): hide search bar on smaller screens

### DIFF
--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -21,6 +21,12 @@
 }
 // Form Styles
 .searchContent {
+  @media screen {
+    @media (max-width: 820px) {
+      display: none;
+    }
+  }
+
   align-items: center;
   background-color: $color_invert_fg;
   border-radius: 4px;


### PR DESCRIPTION
This PR disables the search bar on smaller screens. Styling for the search bar was finicky below` 820px` in width. In the future, we should consider adding/re-styling the search bar to support mobile screen sizes.


## video 📹 

https://user-images.githubusercontent.com/16711614/151477018-c148d25a-53b0-4c8d-a3c9-3ed0352e4e11.mov


https://user-images.githubusercontent.com/16711614/151477142-e4ca3dfb-bbb0-45cf-8d69-a3f7241b66ff.mov

 