### PR TITLE
chore: add hex color codes to story

### DIFF
--- a/frontend/src/stories/styles/Colors.stories.tsx
+++ b/frontend/src/stories/styles/Colors.stories.tsx
@@ -3,6 +3,31 @@ import React from "react";
 import styles from "../../styles/Colors.module.scss";
 import { MultiStory } from "../common/MultiStory";
 
+// Helpers to convert color names to hex values
+function decToHex(value: number) {
+  if (value > 255) {
+    return "FF";
+  } else if (value < 0) {
+    return "00";
+  } else {
+    return value.toString(16).padStart(2, "0").toUpperCase();
+  }
+}
+function rgbToHex(r: number, g: number, b: number) {
+  return "#" + decToHex(r) + decToHex(g) + decToHex(b);
+}
+
+function rgbStringToHexString(rgbString: string) {
+  const rgb = rgbString.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/);
+  if (!rgb) {
+    return rgbString;
+  }
+  const r = parseInt(rgb[1]);
+  const g = parseInt(rgb[2]);
+  const b = parseInt(rgb[3]);
+  return rgbToHex(r, g, b);
+}
+
 const ColorDiv = ({
   color,
   children,
@@ -10,7 +35,25 @@ const ColorDiv = ({
   color: string;
   children: React.ReactNode;
 }) => {
-  return <div className={color}>{children}</div>;
+  // get computer style color from the element on first render and store it to state
+  const [renderedColor, setColor] = React.useState("");
+  React.useEffect(() => {
+    const element = document.getElementsByClassName(color);
+    const elementStyle = window.getComputedStyle(element[0]);
+    const elementColor = elementStyle.getPropertyValue("background-color");
+
+    if (element) {
+      setColor(rgbStringToHexString(elementColor));
+    }
+  }, [color]);
+  return (
+    <div className={color}>
+      <p style={{ justifyContent: "center", backgroundColor: "white" }}>
+        {renderedColor}
+      </p>
+      {children}
+    </div>
+  );
 };
 
 export default {
@@ -22,18 +65,21 @@ export default {
 } as ComponentMeta<typeof ColorDiv>;
 
 // create a storiesArray from every color in styles/Colors.module.scss
-const colorKeys = Object.keys(styles).filter((key) => key.includes("color"));
+let colorKeys = Object.keys(styles).filter((key) => key.includes("color"));
 
-const stories = colorKeys.map((key) => ({
-  label: key.replace("color", "").replace(/_/g, " ").toUpperCase(),
-  story: (
-    <ColorDiv color={styles[key]}>
-      {<div style={{ width: 100, height: 100, margin: 25 }}></div>}
-    </ColorDiv>
-  ),
-}));
+const stories = colorKeys.map((key) => {
+  const label = key.replace("color", "").replace(/_/g, " ").toUpperCase();
+  const container = (
+    <div id={key} style={{ width: 100, height: 100, margin: 25 }}></div>
+  );
 
-const Template: ComponentStory<typeof ColorDiv> = (args) => (
+  return {
+    label,
+    story: <ColorDiv color={styles[key]}>{container}</ColorDiv>,
+  };
+});
+
+const Template: ComponentStory<typeof ColorDiv> = () => (
   <MultiStory
     style={{
       display: "flex",
@@ -46,5 +92,4 @@ const Template: ComponentStory<typeof ColorDiv> = (args) => (
   ></MultiStory>
 );
 
-export const Palette = Template.bind({});
-Palette.args = {};
+export const Colors = Template.bind({});

--- a/frontend/src/styles/Colors.module.scss
+++ b/frontend/src/styles/Colors.module.scss
@@ -182,6 +182,7 @@ $zIndex_globalOverlay: 800;
 .color_bg {
   background-color: #ffffff;
 }
+
 .color_bg_shade {
   background-color: #e8f0f4;
 }
@@ -194,11 +195,11 @@ $zIndex_globalOverlay: 800;
 .color_fg_tint {
   background-color: $color_fg_tint;
 }
-.color_fg_shade {
-  background-color: shade($color_fg, 20%);
-}
 .color_fg_tint2 {
   background-color: tint($color_fg, 40%);
+}
+.color_fg_shade {
+  background-color: shade($color_fg, 20%);
 }
 .color_fg_shade2 {
   background-color: shade($color_fg, 40%);
@@ -212,11 +213,11 @@ $zIndex_globalOverlay: 800;
 .color_chrome_tint {
   background-color: tint($color_chrome, 20%);
 }
-.color_chrome_shade {
-  background-color: shade($color_chrome, 20%);
-}
 .color_chrome_tint2 {
   background-color: tint($color_chrome, 40%);
+}
+.color_chrome_shade {
+  background-color: shade($color_chrome, 20%);
 }
 .color_chrome_shade2 {
   background-color: shade($color_chrome, 40%);
@@ -230,11 +231,11 @@ $zIndex_globalOverlay: 800;
 .color_invert_bg_tint {
   background-color: tint($color_invert_bg, 20%);
 }
-.color_invert_bg_shade {
-  background-color: shade($color_invert_bg, 20%);
-}
 .color_invert_bg_tint2 {
   background-color: tint($color_invert_bg, 40%);
+}
+.color_invert_bg_shade {
+  background-color: shade($color_invert_bg, 20%);
 }
 .color_invert_bg_shade2 {
   background-color: shade($color_invert_bg, 40%);
@@ -254,11 +255,11 @@ $zIndex_globalOverlay: 800;
 .color_invert_chrome_tint {
   background-color: tint($color_invert_chrome, 20%);
 }
-.color_invert_chrome_shade {
-  background-color: shade($color_invert_chrome, 20%);
-}
 .color_invert_chrome_tint2 {
   background-color: tint($color_invert_chrome, 40%);
+}
+.color_invert_chrome_shade {
+  background-color: shade($color_invert_chrome, 20%);
 }
 .color_invert_chrome_shade2 {
   background-color: shade($color_invert_chrome, 40%);
@@ -272,11 +273,11 @@ $zIndex_globalOverlay: 800;
 .color_accent_orange_tint {
   background-color: tint($color_accent_orange, 20%);
 }
-.color_accent_orange_shade {
-  background-color: shade($color_accent_orange, 20%);
-}
 .color_accent_orange_tint2 {
   background-color: tint($color_accent_orange, 40%);
+}
+.color_accent_orange_shade {
+  background-color: shade($color_accent_orange, 20%);
 }
 .color_accent_orange_shade2 {
   background-color: shade($color_accent_orange, 40%);
@@ -287,11 +288,11 @@ $zIndex_globalOverlay: 800;
 .color_accent_blue_tint {
   background-color: tint($color_accent_blue, 20%);
 }
-.color_accent_blue_shade {
-  background-color: shade($color_accent_blue, 20%);
-}
 .color_accent_blue_tint2 {
   background-color: tint($color_accent_blue, 40%);
+}
+.color_accent_blue_shade {
+  background-color: shade($color_accent_blue, 20%);
 }
 .color_accent_blue_shade2 {
   background-color: shade($color_accent_blue, 40%);
@@ -302,11 +303,11 @@ $zIndex_globalOverlay: 800;
 .color_accent_green_tint {
   background-color: tint($color_accent_green, 40%);
 }
-.color_accent_green_shade {
-  background-color: shade($color_accent_green, 20%);
-}
 .color_accent_green_tint2 {
   background-color: tint($color_accent_green, 60%);
+}
+.color_accent_green_shade {
+  background-color: shade($color_accent_green, 20%);
 }
 .color_accent_green_shade2 {
   background-color: shade($color_accent_green, 40%);


### PR DESCRIPTION
This commit adds the hex color codes to the Colors story. This is especially useful when
moving old, hard coded, color styles to using the new Colors module.

## screenshot 🖼️ 
<img width="887" alt="organize-colors-and-add-hex-codes" src="https://user-images.githubusercontent.com/16711614/151477438-d41dec3c-7000-44cb-86f8-85be84cf43bf.png">

