### PR TITLE
refactor(asset-grid): use asset-card component

### DIFF
--- a/frontend/src/components/grids/AssetGrid.tsx
+++ b/frontend/src/components/grids/AssetGrid.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from "react";
-import Imgix from "react-imgix";
 import "../../styles/Grid.css";
 import { ImgixGETAssetsData } from "../../types";
+import { AssetCard } from "../card/AssetCard";
 import { Spinner } from "../Spinner/Spinner";
 import styles from "./AssetGrid.module.scss";
 
@@ -36,42 +36,14 @@ export function AssetGrid({
   };
   const gridItems = assets.map((asset, idx) => {
     return (
-      <div
-        className={`ix-grid-item ${
-          selectedAssetId === asset.id ? "ix-grid-item-selected" : ""
-        }`}
-        key={`${asset.id}-${idx}`}
-        onClick={() => onClick(asset)}
-      >
-        <div className="ix-grid-item-image">
-          <Imgix
-            src={"https://" + domain + asset.attributes.origin_path}
-            imgixParams={{
-              auto: "format",
-              fit: "crop",
-              crop: "entropy",
-            }}
-            /* This sizes attribute is a monster and sets the size of the image
-             * correctly, handling both the SF breakpoints and the design
-             * breakpoints
-             * The SF modal has a breakpoint at 768px (48rem), below which the
-             * modal has a margin around it of 32px, and above which it has a
-             * margin of 5% each side.
-             * In these calculates, the format is:
-             * calc((100vw - SFmargin - modalMargin - betweenColumnMarginSum)/numColumns)
-             * */
-            sizes="(max-width: 500px) calc((100vw - 64px - 32px - 16px)/2),
-            (max-width: 700px) calc((100vw - 64px - 32px - 32px)/3),
-            (max-width: 768px) calc((100vw - 64px - 32px - 48px)/4),
-            (max-width: 820px) calc((100vw - 10vw - 32px - 48px)/4),
-            (max-width: 960px) calc((100vw - 10vw - 32px - 80px)/6),
-            calc((100vw - 10vw - 32px - 96px)/7)"
-          />
-        </div>
-        <p className="ix-grid-item-filename">
-          {domain + asset.attributes.origin_path}
-        </p>
-      </div>
+      <AssetCard
+        key={idx}
+        asset={asset}
+        domain={domain}
+        selectedAssetId={selectedAssetId}
+        layout="grid"
+        onClick={onClick}
+      />
     );
   });
   // show grid error message if error


### PR DESCRIPTION
This PR refactors the AssetGrid component so that it uses the AssetCard component. This
makes it easer to control future styling changes for the AssetCard across all of the
application. It also reduces the cognitive loaod of this component.

## future work

The asset card component is going to need a better way to allow for `sizes` overriding. The current hard-coding isn't going to cut it.
