### PR TITLE
chore: migrate product images modal to typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ frontend/src/stories/assets
 dw*.json
 
 metadata/system-objecttype-extensions.xml
+
+# typescript
+*.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -16,9 +16,12 @@
     "proxyquire": "1.7.4",
     "sfcc-ci": "^2.7.3",
     "sgmf-scripts": "^2.3.0",
-    "sinon": "^1.17.7"
+    "sinon": "^1.17.7",
+    "typescript": "^4.5.5"
   },
   "scripts": {
+    "build": "yarn run build:cartridges",
+    "build:cartridges": "pushd src/cartridges && tsc",
     "test": "sgmf-scripts --test test/unit/**/*.js",
     "setup": "npm run setup:dw-json",
     "setup:dw-json": "node setup.js",

--- a/src/cartridges/SFTypes.ts
+++ b/src/cartridges/SFTypes.ts
@@ -1,0 +1,1 @@
+export type ProductImagesModelData = Record<string, any>;

--- a/src/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.ts
+++ b/src/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.ts
@@ -1,0 +1,205 @@
+"use strict";
+
+import { ProductImagesModelData } from "../../../../SFTypes";
+
+var collections = require("*/cartridge/scripts/util/collections");
+const currentSite = require("dw/system/Site").getCurrent();
+const ProductVariationModel = require("dw/catalog/ProductVariationModel");
+const Variant = require("dw/catalog/Variant");
+const Product = require("dw/catalog/Product");
+
+/**
+ * @constructor
+ * @classdesc Returns images for a given product
+ * @param {dw.catalog.Product} product - product to return images for
+ * @param {Object} imageConfig - configuration object with image types
+ */
+function Images(
+  this: ProductImagesModelData,
+  product: {
+    selectedVariant: any;
+    master: any;
+    custom: { imgixData: string };
+    getImages: (arg0: any) => any;
+  },
+  imageConfig: { types: any[]; quantity: string }
+) {
+  const imgixBaseURL =
+    currentSite.getCustomPreferenceValue("imgixBaseURL") || "";
+  const isBaseURLSet = imgixBaseURL.trim().length > 0;
+  const imgixDefaultParams =
+    currentSite.getCustomPreferenceValue("imgixProductDefaultParams") || "";
+  const imgixEnableProductImageProxy = currentSite.getCustomPreferenceValue(
+    "imgixEnableProductImageProxy"
+  );
+
+  const imgixCustomAttributeData = (() => {
+    if (product instanceof ProductVariationModel) {
+      // Get imgix data custom attribute from selected variant or master product
+      const productData = product.selectedVariant || product.master;
+      return (
+        productData &&
+        productData.custom &&
+        productData.custom.imgixData &&
+        JSON.parse(productData.custom.imgixData)
+      );
+    } else if (product instanceof Variant || product instanceof Product) {
+      return (
+        product.custom &&
+        product.custom.imgixData &&
+        JSON.parse(product.custom.imgixData)
+      );
+    }
+    return undefined;
+  })();
+
+  /* The next section operates in one of three modes:
+   * 1. if custom attribute data exists, use that to render the images (as this
+   *    overrides the built-in SF data)
+   * 2. otherwise, if the imgixBaseURL is set, use that to render the images
+   * 3. fallback to the built-in SF data
+   */
+
+  if (imgixEnableProductImageProxy && imgixCustomAttributeData) {
+    // 1. custom attribute data exists
+
+    imageConfig.types.forEach(function (
+      this: ProductImagesModelData,
+      viewType: string | number
+    ) {
+      const images = (() => {
+        if (imageConfig.quantity === "single") {
+          return [imgixCustomAttributeData.images.primary];
+        }
+        return [
+          imgixCustomAttributeData.images.primary,
+          ...imgixCustomAttributeData.images.alternatives,
+        ];
+      })();
+
+      const result = images.map((image, index) => {
+        // TODO: add tests for default params
+        const imageUrl =
+          image.src +
+          (isBaseURLSet && imgixDefaultParams ? "?" + imgixDefaultParams : "");
+
+        return {
+          alt: image.alt,
+          url: imageUrl,
+          index: index.toString(),
+          title: image.title,
+          absURL: imageUrl,
+        };
+      });
+      this[viewType] = result;
+    },
+    this);
+  } else if (imgixEnableProductImageProxy && isBaseURLSet) {
+    // 2. if the imgixBaseURL is set, use that to render the images
+
+    imageConfig.types.forEach(function (
+      this: ProductImagesModelData,
+      type: string | number
+    ) {
+      var images = product.getImages(type);
+      var result = {};
+
+      if (imageConfig.quantity === "single") {
+        var firstImage = collections.first(images);
+        if (firstImage) {
+          let imageUrl =
+            imgixBaseURL +
+            firstImage.URL.toString() +
+            (isBaseURLSet && imgixDefaultParams
+              ? "?" + imgixDefaultParams
+              : "");
+
+          result = [
+            {
+              alt: firstImage.alt,
+              url: imageUrl,
+              title: firstImage.title,
+              index: "0",
+              absURL: imageUrl,
+            },
+          ];
+        }
+      } else {
+        result = collections.map(
+          images,
+          function (
+            image: { URL: { toString: () => any }; alt: any; title: any },
+            index: { toString: () => any }
+          ) {
+            let imageUrl =
+              imgixBaseURL +
+              image.URL.toString() +
+              (isBaseURLSet && imgixDefaultParams
+                ? "?" + imgixDefaultParams
+                : "");
+
+            return {
+              alt: image.alt,
+              url: imageUrl,
+              index: index.toString(),
+              title: image.title,
+              absURL: imageUrl,
+            };
+          }
+        );
+      }
+      this[type] = result;
+    },
+    this);
+  } else {
+    // 3. fallback to the built-in SF data. Here we just pass through values.
+
+    imageConfig.types.forEach(function (
+      this: ProductImagesModelData,
+      type: string | number
+    ) {
+      var images = product.getImages(type);
+      var result = {};
+
+      if (imageConfig.quantity === "single") {
+        var firstImage = collections.first(images);
+        if (firstImage) {
+          result = [
+            {
+              alt: firstImage.alt,
+              url: firstImage.URL.toString(),
+              title: firstImage.title,
+              index: "0",
+              absURL: firstImage.absURL.toString(),
+            },
+          ];
+        }
+      } else {
+        result = collections.map(
+          images,
+          function (
+            image: {
+              alt: any;
+              URL: { toString: () => any };
+              title: any;
+              absURL: { toString: () => any };
+            },
+            index: { toString: () => any }
+          ) {
+            return {
+              alt: image.alt,
+              url: image.URL.toString(),
+              index: index.toString(),
+              title: image.title,
+              absURL: image.absURL.toString(),
+            };
+          }
+        );
+      }
+      this[type] = result;
+    },
+    this);
+  }
+}
+
+module.exports = Images;

--- a/src/cartridges/tsconfig.json
+++ b/src/cartridges/tsconfig.json
@@ -1,0 +1,102 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Projects */
+    "incremental": true /* Enable incremental compilation */,
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016",
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
+    // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+
+    /* Modules */
+    "module": "commonjs" /* Specify what module code is generated. */,
+    "rootDir": "./" /* Specify the root folder within your source files. */,
+    "outDir": "../../cartridges/",
+    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files */
+    // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    "allowSyntheticDefaultImports": true /* Allow 'import x from y' when a module doesn't have a default export. */,
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+    /* Type Checking */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+    // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
+    // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5084,6 +5084,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+
 uglify-js@^3.1.4:
   version "3.14.4"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.14.4.tgz#68756f17d1b90b9d289341736cb9a567d6882f90"


### PR DESCRIPTION
This PR is born out of frustration of writing plain JS without type checking, causing potentially future problems in the development of the product images model (and other SF JS). This is not fixed in stone, and am willing to revert this if there is a significant pushback.
