### PR TITLE
fix: update cartridge build script so it doesn't break on ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "yarn run build:cartridges",
-    "build:cartridges": "pushd src/cartridges && tsc",
+    "build:cartridges": "cd src/cartridges && tsc",
     "test": "sgmf-scripts --test test/unit/**/*.js",
     "setup": "npm run setup:dw-json",
     "setup:dw-json": "node setup.js",


### PR DESCRIPTION
This PR aims to fix the build script that's breaking on CI. `pushd` cannot be used on our circleCI instance.
