### PR TITLE
chore: use new types in extension and asset-card

### DIFF
--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -1,14 +1,15 @@
 import React from "react";
 import "../styles/App.css";
-import { IImgixCustomAttributeValue } from "../types/imgixSF";
+import { IProductImageData } from "../types/";
 import { ProductPageImages } from "./ProductPageImages";
 
 export type ISidebarAppProps = {
   onChange: (value: string) => void;
-  images: IImgixCustomAttributeValue[] | undefined;
+  data: IProductImageData | undefined;
 };
 
-export function ExtensionApp({ onChange, images }: ISidebarAppProps) {
+export function ExtensionApp({ onChange, data }: ISidebarAppProps) {
+  const images = data?.images || [];
   const disabled = images === undefined || images.length === 0;
   const onOpenBreakoutClick = () => {
     console.log("[imgix] onOpenBreakoutClick");

--- a/frontend/src/components/ProductImage/ProductImageContainer.module.scss
+++ b/frontend/src/components/ProductImage/ProductImageContainer.module.scss
@@ -1,10 +1,38 @@
+@import "../../styles/Colors.module.scss";
+
 .imageWrapper {
-  background-color: #e3e7eb;
-  height: 60px;
-  width: 60px;
+  background-color: $color_bg_new;
   overflow: hidden;
   display: flex;
   margin: 5px;
-  min-width: 60px;
+  max-width: 200px;
   position: relative;
+}
+
+.replaceImageButton {
+  color: $color_invert_fg;
+}
+
+.assetButtonsContainer {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  font-size: $type_size_small;
+  justify-content: space-between;
+  padding-left: 5px;
+  padding-right: 30px;
+
+  .assetButtons {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    font-size: $type_size_small;
+    justify-content: space-between;
+    padding: 10px 0 10px 0px;
+    width: 70px;
+
+    p {
+      margin-left: 10px;
+    }
+  }
 }

--- a/frontend/src/components/ProductImage/ProductImageContainer.tsx
+++ b/frontend/src/components/ProductImage/ProductImageContainer.tsx
@@ -1,17 +1,19 @@
 import React, { ReactElement } from "react";
-import Imgix from "react-imgix";
-import { IImgixCustomAttributeValue } from "../../types/imgixSF";
+import { IProductImage } from "../../types/";
+import { FrameButton } from "../buttons/FrameButton/FrameButton";
 import { ReplaceButton } from "../buttons/ReplaceButton";
+import { AssetCard } from "../card/AssetCard";
+import { Divider } from "../dividers/Divider";
 import { Overlay } from "../layouts/Overlay";
 import styles from "./ProductImageContainer.module.scss";
 
 interface Props {
   onOpenBreakoutClick: () => void;
-  value: IImgixCustomAttributeValue;
+  image: IProductImage;
 }
 
 export const ProductImageContainer = ({
-  value,
+  image,
   onOpenBreakoutClick,
 }: Props): ReactElement => {
   const [hovering, setHovering] = React.useState(false);
@@ -25,21 +27,36 @@ export const ProductImageContainer = ({
   };
 
   return (
-    <div
-      className={styles.imageWrapper}
-      onClick={onOpenBreakoutClick}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-    >
-      <Overlay visible={hovering}>
-        <ReplaceButton />
-      </Overlay>
-      <Imgix
-        height={60}
-        imgixParams={{ fit: "crop" }}
-        src={value.src}
-        width={60}
-      />
+    <div style={{ minWidth: 342, display: "flex" }}>
+      <div
+        className={styles.imageWrapper}
+        onClick={onOpenBreakoutClick}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      >
+        <Overlay rounded visible={hovering}>
+          <ReplaceButton label="REPLACE" />
+        </Overlay>
+        <AssetCard
+          asset={image?.imgix_metadata}
+          domain={image?.imgix_metadata?.base_url || ""}
+        />
+      </div>
+      <div className={styles.assetButtonsContainer}>
+        <div className={styles.assetButtons}>
+          <FrameButton size="small" color="primary" />
+          <p>Large</p>
+        </div>
+        <div className={styles.assetButtons}>
+          <FrameButton size="small" color="primary" />
+          <p>Medium</p>
+        </div>
+        <div className={styles.assetButtons}>
+          <FrameButton size="small" color="primary" />
+          <p>Small</p>
+        </div>
+      </div>
+      <Divider vertical />
     </div>
   );
 };

--- a/frontend/src/components/ProductPageImages.module.scss
+++ b/frontend/src/components/ProductPageImages.module.scss
@@ -1,0 +1,23 @@
+@import "../styles/Colors.module.scss";
+
+.addImageButtonContainer {
+  display: flex;
+  justify-content: center;
+  justify-self: stretch;
+  background: $color_invert_fg;
+  border-radius: 4px;
+  cursor: pointer;
+  min-height: 200px;
+  min-width: 200px;
+  overflow: hidden;
+  margin: 2px;
+  padding-top: 84px;
+
+  &:hover {
+    box-shadow: 0 0 0 2px $color_fg;
+  }
+
+  &:active {
+    box-shadow: 0 0 0 2px $color_fg_tint2;
+  }
+}

--- a/frontend/src/components/ProductPageImages.tsx
+++ b/frontend/src/components/ProductPageImages.tsx
@@ -1,12 +1,15 @@
 import React, { ReactElement } from "react";
-import { IImgixCustomAttributeValue } from "../types/imgixSF";
-import { AddButton } from "./buttons/AddButton";
+import { IProductImage } from "../types";
+import { FrameButton } from "./buttons/FrameButton/FrameButton";
+import { Divider } from "./dividers/Divider";
+import { AddSvg } from "./icons";
 import { OverflowScrollX } from "./layouts/OverflowScrollX";
 import { ProductImageContainer } from "./ProductImage/ProductImageContainer";
+import styles from "./ProductPageImages.module.scss";
 
 export interface ProductPageImagesProps {
   disabled: boolean;
-  images: IImgixCustomAttributeValue[] | undefined;
+  images: IProductImage[] | undefined;
   onClick: () => void;
 }
 
@@ -17,21 +20,24 @@ export const ProductPageImages = ({
 }: ProductPageImagesProps): ReactElement => {
   return (
     <OverflowScrollX>
-      <div style={{ margin: 5, minWidth: 120, display: "flex" }}>
-        <AddButton
-          disabled={disabled}
-          label="ADD IMAGE"
-          onOpenBreakoutClick={onClick}
+      <div className={styles.addImageButtonContainer}>
+        <FrameButton
+          frameless
+          label="Add Image"
+          color="tertiary"
+          className={styles.addImageButton}
+          icon={<AddSvg />}
         />
       </div>
+      <Divider vertical />
       <>
         {/* we have to create a fragment around jsx elements otherwise
         typescript will throw an error */}
-        {images?.map((image: IImgixCustomAttributeValue) => {
+        {images?.map((image: IProductImage) => {
           return (
             <ProductImageContainer
               onOpenBreakoutClick={onClick}
-              value={{ ...image } as IImgixCustomAttributeValue}
+              image={{ ...image } as IProductImage}
             />
           );
         })}

--- a/frontend/src/components/card/AssetCard.tsx
+++ b/frontend/src/components/card/AssetCard.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement } from "react";
-import { ImgixGETAssetsData } from "../../types";
+import { IImgixMetadata, ImgixGETAssetsData } from "../../types";
 import { AssetCardImage } from "../image/AssetCardImage";
 import styles from "./AssetCard.module.scss";
 
 interface AssetCardProps {
-  asset: ImgixGETAssetsData[0];
+  asset: ImgixGETAssetsData[0] | IImgixMetadata | undefined;
   domain: string;
   height?: string;
   layout?: "grid" | "list";
@@ -26,7 +26,7 @@ export function AssetCard({
 }: AssetCardProps): ReactElement {
   // Strip filename from asset.attributes.origin_path
   const filename =
-    asset.attributes.origin_path.split("/").pop()?.split("?")[0] || "";
+    asset?.attributes.origin_path.split("/").pop()?.split("?")[0] || "";
   const isImage = filename.match(
     /\.(avif|gif|jp2|jpg|jpeg|json|jxr|pjpg|png|png8|png32|webp|blurhash|svg|ai)$/
   );
@@ -35,12 +35,15 @@ export function AssetCard({
     styles.container,
     layout === "list" ? styles.list : styles.grid,
     !isImage ? styles.disabled : "",
-    selectedAssetId === asset.id ? styles.selected : "",
+    selectedAssetId === asset?.id ? styles.selected : "",
     noFilepath ? styles["h-200"] : "",
   ].join(" ");
 
   return (
-    <div className={containerStyles} onClick={() => onClick && onClick(asset)}>
+    <div
+      className={containerStyles}
+      onClick={() => onClick && asset && onClick(asset)}
+    >
       {isImage ? (
         <div style={{ height }} className={styles.image}>
           <AssetCardImage asset={asset} domain={domain} />

--- a/frontend/src/components/card/AssetCard.tsx
+++ b/frontend/src/components/card/AssetCard.tsx
@@ -11,7 +11,7 @@ interface AssetCardProps {
   noFilepath?: boolean;
   placeholder?: string;
   selectedAssetId?: string;
-  onClick?: (data: Object) => void;
+  onClick?: (data: ImgixGETAssetsData[0] | IImgixMetadata) => void;
 }
 
 export function AssetCard({

--- a/frontend/src/components/card/AssetCard.tsx
+++ b/frontend/src/components/card/AssetCard.tsx
@@ -50,7 +50,7 @@ export function AssetCard({
         </div>
       ) : (
         <div style={{ height }} className={styles.placeholder}>
-          <img src={placeholder} />
+          <img alt="" src={placeholder} />
         </div>
       )}
       {noFilepath ? null : <p className={styles.filename}>{filename}</p>}

--- a/frontend/src/components/grids/AssetGrid.tsx
+++ b/frontend/src/components/grids/AssetGrid.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from "react";
-import Imgix from "react-imgix";
 import "../../styles/Grid.css";
 import { ImgixGETAssetsData } from "../../types";
+import { AssetCard } from "../card/AssetCard";
 import { Spinner } from "../Spinner/Spinner";
 import styles from "./AssetGrid.module.scss";
 
@@ -36,42 +36,14 @@ export function AssetGrid({
   };
   const gridItems = assets.map((asset, idx) => {
     return (
-      <div
-        className={`ix-grid-item ${
-          selectedAssetId === asset.id ? "ix-grid-item-selected" : ""
-        }`}
-        key={`${asset.id}-${idx}`}
-        onClick={() => onClick(asset)}
-      >
-        <div className="ix-grid-item-image">
-          <Imgix
-            src={"https://" + domain + asset.attributes.origin_path}
-            imgixParams={{
-              auto: "format",
-              fit: "crop",
-              crop: "entropy",
-            }}
-            /* This sizes attribute is a monster and sets the size of the image
-             * correctly, handling both the SF breakpoints and the design
-             * breakpoints
-             * The SF modal has a breakpoint at 768px (48rem), below which the
-             * modal has a margin around it of 32px, and above which it has a
-             * margin of 5% each side.
-             * In these calculates, the format is:
-             * calc((100vw - SFmargin - modalMargin - betweenColumnMarginSum)/numColumns)
-             * */
-            sizes="(max-width: 500px) calc((100vw - 64px - 32px - 16px)/2),
-            (max-width: 700px) calc((100vw - 64px - 32px - 32px)/3),
-            (max-width: 768px) calc((100vw - 64px - 32px - 48px)/4),
-            (max-width: 820px) calc((100vw - 10vw - 32px - 48px)/4),
-            (max-width: 960px) calc((100vw - 10vw - 32px - 80px)/6),
-            calc((100vw - 10vw - 32px - 96px)/7)"
-          />
-        </div>
-        <p className="ix-grid-item-filename">
-          {domain + asset.attributes.origin_path}
-        </p>
-      </div>
+      <AssetCard
+        key={idx}
+        asset={asset}
+        domain={domain}
+        selectedAssetId={selectedAssetId}
+        layout="grid"
+        onClick={onClick}
+      />
     );
   });
   // show grid error message if error

--- a/frontend/src/components/image/AssetCardImage.tsx
+++ b/frontend/src/components/image/AssetCardImage.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 import Imgix from "react-imgix";
-import { ImgixGETAssetsData } from "../../types";
+import { IImgixMetadata, ImgixGETAssetsData } from "../../types";
 
 type Props = {
-  asset: ImgixGETAssetsData[0];
+  asset: ImgixGETAssetsData[0] | IImgixMetadata | undefined;
   domain: string;
 };
 
 export function AssetCardImage({ asset, domain }: Props) {
   return (
     <Imgix
-      src={"https://" + domain + asset.attributes.origin_path}
+      src={"https://" + domain + asset?.attributes.origin_path}
       imgixParams={{
         auto: "format",
         fit: "crop",

--- a/frontend/src/index-extension.tsx
+++ b/frontend/src/index-extension.tsx
@@ -37,7 +37,7 @@ export const injectExtensionApp = () => {
 
   const data = {
     images: customAttributeValue.images || [],
-    swatchImages: customAttributeValue?.swatchImages,
+    swatches: customAttributeValue?.swatches,
   };
 
   // uncomment next line and setCustomAttributeValue function when React app is ready

--- a/frontend/src/index-extension.tsx
+++ b/frontend/src/index-extension.tsx
@@ -35,40 +35,14 @@ export const injectExtensionApp = () => {
 
   const customAttributeValue = JSON.parse(customAttributeTextarea.value);
 
-  // reduce the custom attribute value to an array of images, where each image
-  // is an object with src, sourceWidth, and imageType properties
-  const storeCustomAttributeImages = (customAttributeValue: any) => {
-    let customImages = [];
-    // add the primary image to the array of images
-    customImages.push({
-      src: customAttributeValue?.images?.primary?.src,
-      sourceWidth: customAttributeValue?.images?.primary?.sourceWidth,
-      imageType: "primary",
-    });
-    customImages.push(
-      ...customAttributeValue?.images?.alternatives?.map((image: any) => ({
-        src: image.src,
-        sourceWidth: image.sourceWidth,
-        imageType: "alternative",
-      }))
-    );
-    // add the swatch images to the array of images
-    customImages.push(
-      ...customAttributeValue?.swatchImages?.map((image: any) => ({
-        src: image.src,
-        sourceWidth: image.sourceWidth,
-        imageType: "swatch",
-      }))
-    );
-
-    return customImages;
+  const data = {
+    images: customAttributeValue.images || [],
+    swatchImages: customAttributeValue?.swatchImages,
   };
-
-  const images = storeCustomAttributeImages(customAttributeValue);
 
   // uncomment next line and setCustomAttributeValue function when React app is ready
   ReactDOM.render(
-    <ExtensionApp images={images} onChange={setCustomAttributeValue} />,
+    <ExtensionApp data={data} onChange={setCustomAttributeValue} />,
     newTD
   );
 };

--- a/frontend/src/stories/Card.stories.tsx
+++ b/frontend/src/stories/Card.stories.tsx
@@ -1,35 +1,37 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { AssetCard } from "../components/card/AssetCard";
+import { AssetCard as _AssetCard } from "../components/card/AssetCard";
 import { MultiStory } from "./common/MultiStory";
 
 export default {
-  title: "Example/Image Card",
-  component: AssetCard,
+  title: "Example/Asset Card",
+  component: _AssetCard,
   parameters: {
     layout: "centered",
   },
-} as ComponentMeta<typeof AssetCard>;
+} as ComponentMeta<typeof _AssetCard>;
 
-const Template: ComponentStory<typeof AssetCard> = (args) => (
+const Template: ComponentStory<typeof _AssetCard> = (args) => (
   <MultiStory
     stories={[
       {
         label: "Normal",
-        story: <AssetCard {...args} />,
+        story: <_AssetCard {...args} />,
       },
       {
         label: "with unsupported file formal",
         story: (
-          <AssetCard
-            {...{
-              ...args,
-              asset: {
-                ...args.asset,
-                attributes: {
-                  ...args.asset.attributes,
-                  origin_path: "/amsterdam.mp4",
-                },
+          <_AssetCard
+            {...args}
+            asset={{
+              id: "1",
+              type: "assets",
+              attributes: {
+                origin_path: "/amsterdam.mov",
+                description: "",
+                name: "",
+                media_width: 0,
+                media_height: 0,
               },
             }}
           />
@@ -39,15 +41,17 @@ const Template: ComponentStory<typeof AssetCard> = (args) => (
       {
         label: "with invalid path",
         story: (
-          <AssetCard
-            {...{
-              ...args,
-              asset: {
-                ...args.asset,
-                attributes: {
-                  ...args.asset.attributes,
-                  origin_path: "/_amsterdam.jpg",
-                },
+          <_AssetCard
+            {...args}
+            asset={{
+              id: "2",
+              type: "assets",
+              attributes: {
+                origin_path: "/_amsterdam.jpg",
+                description: "",
+                name: "",
+                media_width: 0,
+                media_height: 0,
               },
             }}
           />
@@ -58,10 +62,10 @@ const Template: ComponentStory<typeof AssetCard> = (args) => (
   />
 );
 
-export const Simple = Template.bind({});
-Simple.args = {
+export const AssetCard = Template.bind({});
+AssetCard.args = {
   asset: {
-    id: "1",
+    id: "0",
     type: "assets",
     attributes: {
       origin_path: "/amsterdam.jpg",
@@ -72,6 +76,6 @@ Simple.args = {
     },
   },
   domain: "sdk-test.imgix.net",
-  selectedAssetId: "1",
+  selectedAssetId: "",
   onClick: () => {},
 };

--- a/frontend/src/stories/extension/ProductImageContainer.stories.tsx
+++ b/frontend/src/stories/extension/ProductImageContainer.stories.tsx
@@ -4,7 +4,7 @@ import {
   ProductPageImages,
   ProductPageImagesProps,
 } from "../../components/ProductPageImages";
-import { IImgixCustomAttributeValue } from "../../types/imgixSF";
+import { IProductImage } from "../../types";
 import { MultiStory } from "../common/MultiStory";
 
 export default {
@@ -16,13 +16,47 @@ export default {
 const selectedImage = [
   {
     src: "https://sdk-test.imgix.net/amsterdam.jpg",
+    view_type: {
+      large: true,
+      medium: true,
+      small: true,
+    },
+    imgix_metadata: {
+      attributes: {
+        description: "amsterdam",
+        name: "/amsterdam.jpg",
+        origin_path: "/amsterdam.jpg",
+        media_height: 0,
+        media_width: 0,
+      },
+      base_url: "sdk-test.imgix.net",
+      id: "1",
+      type: "assets",
+    },
   },
-] as IImgixCustomAttributeValue[];
+] as IProductImage[];
 const selectedImages: any = [];
 
-for (let i = 0; i < 50; i++) {
+for (let i = 0; i < 15; i++) {
   selectedImages.push({
     src: "https://sdk-test.imgix.net/amsterdam.jpg",
+    view_type: {
+      large: true,
+      medium: true,
+      small: true,
+    },
+    imgix_metadata: {
+      attributes: {
+        description: "amsterdam",
+        name: "/amsterdam.jpg",
+        origin_path: "/amsterdam.jpg",
+        media_height: 0,
+        media_width: 0,
+      },
+      base_url: "sdk-test.imgix.net",
+      id: i + 5,
+      type: "assets",
+    },
   });
 }
 
@@ -35,11 +69,11 @@ const Template: ComponentStory<typeof ProductPageImages> = (args) => (
       },
       {
         label: "With selected image",
-        story: <ProductPageImages {...{ ...args, images: selectedImage }} />,
+        story: <ProductPageImages {...args} images={selectedImage} />,
       },
       {
         label: "With many selected images",
-        story: <ProductPageImages {...{ ...args, images: selectedImages }} />,
+        story: <ProductPageImages {...args} images={selectedImages} />,
       },
     ]}
     style={{
@@ -49,6 +83,4 @@ const Template: ComponentStory<typeof ProductPageImages> = (args) => (
 );
 
 export const ProductImages = Template.bind({});
-ProductImages.args = {
-  images: selectedImage,
-} as ProductPageImagesProps;
+ProductImages.args = {} as ProductPageImagesProps;

--- a/frontend/src/stories/extension/products.stories.tsx
+++ b/frontend/src/stories/extension/products.stories.tsx
@@ -54,19 +54,28 @@ export const SFImgixProductsSection = () => {
                       className={`${styles.w100} ${styles.textarea}`}
                     >
                       {JSON.stringify({
-                        images: {
-                          primary: {
-                            src:
-                              "https://cc-zybp-002-sandbox.imgix.net/on/demandware.static/-/Sites-apparel-m-catalog/default/dwdb18b57a/images/large/PG.10221714.JJ169XX.PZ.jpg",
-                          },
-                          alternatives: [
-                            {
-                              src:
-                                "https://cc-zybp-002-sandbox.imgix.net/on/demandware.static/-/Sites-apparel-m-catalog/default/dwd910a0e9/images/large/PG.10221714.JJ169XX.BZ.jpg",
-                              sourceWidth: 3000,
+                        images: [
+                          {
+                            src: "https://sdk-test.imgix.net/amsterdam.jpg",
+                            view_type: {
+                              large: true,
+                              medium: true,
+                              small: true,
                             },
-                          ],
-                        },
+                            imgix_metadata: {
+                              attributes: {
+                                description: "amsterdam",
+                                name: "/amsterdam.jpg",
+                                origin_path: "/amsterdam.jpg",
+                                media_height: 0,
+                                media_width: 0,
+                              },
+                              base_url: "sdk-test.imgix.net",
+                              id: "1",
+                              type: "assets",
+                            },
+                          },
+                        ],
                         swatchImages: [
                           {
                             src:

--- a/frontend/src/stories/styles/Grid.stories.tsx
+++ b/frontend/src/stories/styles/Grid.stories.tsx
@@ -41,14 +41,16 @@ const Template: ComponentStory<typeof AssetCard> = (args) => (
           <_Grid>
             {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14].map((i) => (
               <AssetCard
-                {...{
-                  ...args,
-                  asset: {
-                    ...args.asset,
-                    attributes: {
-                      ...args.asset.attributes,
-                      origin_path: `/amsterdam.jpg?txt=${i}&txt-size=24&txt-color=ffff&txt-align=middle,center&txt-font=Futura%20Condensed%20Medium`,
-                    },
+                {...args}
+                asset={{
+                  id: "1",
+                  type: "assets",
+                  attributes: {
+                    origin_path: `/amsterdam.jpg?txt=${i}&txt-size=24&txt-color=ffff&txt-align=middle,center&txt-font=Futura%20Condensed%20Medium`,
+                    description: "",
+                    name: "",
+                    media_width: 0,
+                    media_height: 0,
                   },
                 }}
               />


### PR DESCRIPTION
## Before this PR
- `ExtensionApp.tsx`, `AssetCard.tsx`, & `AssetCardImage.tsx` could not use 
  - `IImgixMetadata`
  - `IImgixCustomAttributeImage`
  - `IImgixCustomAttributeSwatch`, or 
  - `IImgixCustomAttribute` types.

## After this PR
The component prop type definitions include these new types.