### PR TITLE
refactor(asset-grid): use asset-card

### DIFF
--- a/frontend/src/components/card/AssetCard.tsx
+++ b/frontend/src/components/card/AssetCard.tsx
@@ -11,7 +11,7 @@ interface AssetCardProps {
   noFilepath?: boolean;
   placeholder?: string;
   selectedAssetId?: string;
-  onClick?: (data: Object) => void;
+  onClick?: (data: ImgixGETAssetsData[0] | IImgixMetadata) => void;
 }
 
 export function AssetCard({

--- a/frontend/src/components/card/AssetCard.tsx
+++ b/frontend/src/components/card/AssetCard.tsx
@@ -50,7 +50,7 @@ export function AssetCard({
         </div>
       ) : (
         <div style={{ height }} className={styles.placeholder}>
-          <img src={placeholder} />
+          <img alt="" src={placeholder} />
         </div>
       )}
       {noFilepath ? null : <p className={styles.filename}>{filename}</p>}

--- a/frontend/src/components/grids/AssetGrid.tsx
+++ b/frontend/src/components/grids/AssetGrid.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from "react";
-import Imgix from "react-imgix";
 import "../../styles/Grid.css";
 import { ImgixGETAssetsData } from "../../types";
+import { AssetCard } from "../card/AssetCard";
 import { Spinner } from "../Spinner/Spinner";
 import styles from "./AssetGrid.module.scss";
 
@@ -36,42 +36,14 @@ export function AssetGrid({
   };
   const gridItems = assets.map((asset, idx) => {
     return (
-      <div
-        className={`ix-grid-item ${
-          selectedAssetId === asset.id ? "ix-grid-item-selected" : ""
-        }`}
-        key={`${asset.id}-${idx}`}
-        onClick={() => onClick(asset)}
-      >
-        <div className="ix-grid-item-image">
-          <Imgix
-            src={"https://" + domain + asset.attributes.origin_path}
-            imgixParams={{
-              auto: "format",
-              fit: "crop",
-              crop: "entropy",
-            }}
-            /* This sizes attribute is a monster and sets the size of the image
-             * correctly, handling both the SF breakpoints and the design
-             * breakpoints
-             * The SF modal has a breakpoint at 768px (48rem), below which the
-             * modal has a margin around it of 32px, and above which it has a
-             * margin of 5% each side.
-             * In these calculates, the format is:
-             * calc((100vw - SFmargin - modalMargin - betweenColumnMarginSum)/numColumns)
-             * */
-            sizes="(max-width: 500px) calc((100vw - 64px - 32px - 16px)/2),
-            (max-width: 700px) calc((100vw - 64px - 32px - 32px)/3),
-            (max-width: 768px) calc((100vw - 64px - 32px - 48px)/4),
-            (max-width: 820px) calc((100vw - 10vw - 32px - 48px)/4),
-            (max-width: 960px) calc((100vw - 10vw - 32px - 80px)/6),
-            calc((100vw - 10vw - 32px - 96px)/7)"
-          />
-        </div>
-        <p className="ix-grid-item-filename">
-          {domain + asset.attributes.origin_path}
-        </p>
-      </div>
+      <AssetCard
+        key={idx}
+        asset={asset}
+        domain={domain}
+        selectedAssetId={selectedAssetId}
+        layout="grid"
+        onClick={onClick}
+      />
     );
   });
   // show grid error message if error

--- a/frontend/src/stories/Card.stories.tsx
+++ b/frontend/src/stories/Card.stories.tsx
@@ -1,35 +1,37 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { AssetCard } from "../components/card/AssetCard";
+import { AssetCard as _AssetCard } from "../components/card/AssetCard";
 import { MultiStory } from "./common/MultiStory";
 
 export default {
-  title: "Example/Image Card",
-  component: AssetCard,
+  title: "Example/Asset Card",
+  component: _AssetCard,
   parameters: {
     layout: "centered",
   },
-} as ComponentMeta<typeof AssetCard>;
+} as ComponentMeta<typeof _AssetCard>;
 
-const Template: ComponentStory<typeof AssetCard> = (args) => (
+const Template: ComponentStory<typeof _AssetCard> = (args) => (
   <MultiStory
     stories={[
       {
         label: "Normal",
-        story: <AssetCard {...args} />,
+        story: <_AssetCard {...args} />,
       },
       {
         label: "with unsupported file formal",
         story: (
-          <AssetCard
-            {...{
-              ...args,
-              asset: {
-                ...args.asset,
-                attributes: {
-                  ...args.asset.attributes,
-                  origin_path: "/amsterdam.mp4",
-                },
+          <_AssetCard
+            {...args}
+            asset={{
+              id: "1",
+              type: "assets",
+              attributes: {
+                origin_path: "/amsterdam.mov",
+                description: "",
+                name: "",
+                media_width: 0,
+                media_height: 0,
               },
             }}
           />
@@ -39,15 +41,17 @@ const Template: ComponentStory<typeof AssetCard> = (args) => (
       {
         label: "with invalid path",
         story: (
-          <AssetCard
-            {...{
-              ...args,
-              asset: {
-                ...args.asset,
-                attributes: {
-                  ...args.asset.attributes,
-                  origin_path: "/_amsterdam.jpg",
-                },
+          <_AssetCard
+            {...args}
+            asset={{
+              id: "2",
+              type: "assets",
+              attributes: {
+                origin_path: "/_amsterdam.jpg",
+                description: "",
+                name: "",
+                media_width: 0,
+                media_height: 0,
               },
             }}
           />
@@ -58,10 +62,10 @@ const Template: ComponentStory<typeof AssetCard> = (args) => (
   />
 );
 
-export const Simple = Template.bind({});
-Simple.args = {
+export const AssetCard = Template.bind({});
+AssetCard.args = {
   asset: {
-    id: "1",
+    id: "0",
     type: "assets",
     attributes: {
       origin_path: "/amsterdam.jpg",
@@ -72,6 +76,6 @@ Simple.args = {
     },
   },
   domain: "sdk-test.imgix.net",
-  selectedAssetId: "1",
+  selectedAssetId: "",
   onClick: () => {},
 };

--- a/frontend/src/stories/styles/Grid.stories.tsx
+++ b/frontend/src/stories/styles/Grid.stories.tsx
@@ -41,14 +41,16 @@ const Template: ComponentStory<typeof AssetCard> = (args) => (
           <_Grid>
             {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14].map((i) => (
               <AssetCard
-                {...{
-                  ...args,
-                  asset: {
-                    ...args.asset,
-                    attributes: {
-                      ...args.asset.attributes,
-                      origin_path: `/amsterdam.jpg?txt=${i}&txt-size=24&txt-color=ffff&txt-align=middle,center&txt-font=Futura%20Condensed%20Medium`,
-                    },
+                {...args}
+                asset={{
+                  id: "1",
+                  type: "assets",
+                  attributes: {
+                    origin_path: `/amsterdam.jpg?txt=${i}&txt-size=24&txt-color=ffff&txt-align=middle,center&txt-font=Futura%20Condensed%20Medium`,
+                    description: "",
+                    name: "",
+                    media_width: 0,
+                    media_height: 0,
                   },
                 }}
               />


### PR DESCRIPTION
## Before this PR
Each card was hardcoded onto the `AssetGrid.tsx` component.

## After this PR
The component uses the `AssetCard.tsx` component for each card.

## screenshot 🖼️ 

- before
<img width="354" alt="asset-grid-before" src="https://user-images.githubusercontent.com/16711614/151860208-f35e8b12-5f6c-40ce-88e0-e8141934d50e.png">

- after
<img width="382" alt="asset-grid-after" src="https://user-images.githubusercontent.com/16711614/151860215-f5358967-d654-4f9b-9e03-b598a4d619ab.png">