### PR TITLE
feat(extension): open im-modal on click

### DIFF
--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -1,23 +1,38 @@
 import React from "react";
 import "../styles/App.css";
 import { IProductImageData } from "../types/";
+import { AssetBrowserContainer } from "./AssetBrowser/AssetBrowserContainer";
+import { Modal } from "./layouts/Modal";
 import { ProductPageImages } from "./ProductPageImages";
 
 export type ISidebarAppProps = {
   onChange: (value: string) => void;
+  apiKey: string | null;
   data: IProductImageData | undefined;
 };
 
-export function ExtensionApp({ onChange, data }: ISidebarAppProps) {
+export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
   const images = data?.images || [];
   const disabled = images === undefined || images.length === 0;
   const onOpenBreakoutClick = () => {
-    console.log("[imgix] onOpenBreakoutClick");
+    console.log("[imgix] open imgix modal");
+    setIsModalOpen(true);
   };
+
   return (
     <div className="App">
       <header className="App-header">
         <div>
+          <Modal
+            locked={false}
+            onClose={() => {
+              setIsModalOpen(false);
+            }}
+            open={isModalOpen}
+          >
+            <AssetBrowserContainer apiKey={apiKey} />
+          </Modal>
           <ProductPageImages
             onClick={onOpenBreakoutClick}
             images={images}

--- a/frontend/src/components/layouts/Modal.tsx
+++ b/frontend/src/components/layouts/Modal.tsx
@@ -15,7 +15,7 @@ export function Modal({ children, locked, open, onClose }: ModalProps) {
   React.useEffect(() => {
     const { current } = backdrop;
 
-    const keyHandler = (e: KeyboardEvent) => e.key == "Escape" && onClose();
+    const keyHandler = (e: KeyboardEvent) => e.key === "Escape" && onClose();
 
     const clickHandler = (e: MouseEvent) =>
       !locked && e.target === current && onClose();

--- a/frontend/src/index-extension.tsx
+++ b/frontend/src/index-extension.tsx
@@ -42,7 +42,8 @@ export const injectExtensionApp = () => {
 
   // uncomment next line and setCustomAttributeValue function when React app is ready
   ReactDOM.render(
-    <ExtensionApp data={data} onChange={setCustomAttributeValue} />,
+    // TODO: enter the actual api key from browser storage here
+    <ExtensionApp apiKey={""} data={data} onChange={setCustomAttributeValue} />,
     newTD
   );
 };


### PR DESCRIPTION
This PR has the `ExtensionApp` component accept an `apiKey` string prop. It then passes that prop onto the `AssetBrowserContainer` component inside a `Modal` component. The modal only opens once the user has clicked on one of the buttons inside the `ProductImageContainer`.

## Screen recording
[modal-open-on-click.mov](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/0d94ec17-f2ec-47aa-9b1f-ce1901857683/modal-open-on-click.mov)