### PR TITLE
fix: enforce border-box for box-sizing

### DIFF
--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -110,9 +110,6 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
       console.log("[imgix] adding asset to product images");
       const newImages = [...productImages, selectedAssetImage];
       updateProductImages(newImages);
-    } else {
-      // TODO: this _should_ be dead code. Need to remove.
-      console.log("[imgix] selectedAssetImage does not exist, not adding data");
     }
     closeModal();
   };

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -81,14 +81,23 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
       title: metadata.attributes.name || metadata.attributes.origin_path,
       alt: metadata.attributes.name || metadata.attributes.origin_path,
     };
-
-    setSelectedAssetImage(newImage);
+    // If selected image already in data, set selectedAssetImage to undefined.
+    // This will disable the add-image button.
+    if (
+      productImages.find(
+        (image) => image.imgix_metadata?.id === newImage.imgix_metadata?.id
+      )
+    ) {
+      setSelectedAssetImage(undefined);
+    } else {
+      setSelectedAssetImage(newImage);
+    }
   };
 
   const saveSelectionToDataOnClick = () => {
     if (selectedProductImageId && selectedAssetImage) {
-      console.log("[imgix] selectedAssetImage exists, replacing data");
-      // for image with matching id, replace the image with the selected asset
+      console.log("[imgix] replacing product image");
+      // replace product image with selected asset image
       const newImages = productImages.map((image) => {
         if (image.imgix_metadata?.id === selectedProductImageId) {
           return selectedAssetImage;
@@ -97,21 +106,12 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
       });
       updateProductImages(newImages || []);
     } else if (selectedAssetImage) {
-      console.log("[imgix] asset selected, adding to data");
-      // if image id already exists, do nothing
-      if (
-        productImages.find(
-          (image) =>
-            image.imgix_metadata?.id === selectedAssetImage.imgix_metadata?.id
-        )
-      ) {
-        return;
-      } else {
-        // otherwise, add the image to the data
-        const newImages = [...productImages, selectedAssetImage];
-        updateProductImages(newImages);
-      }
+      // add product image to data
+      console.log("[imgix] adding asset to product images");
+      const newImages = [...productImages, selectedAssetImage];
+      updateProductImages(newImages);
     } else {
+      // TODO: this _should_ be dead code. Need to remove.
       console.log("[imgix] selectedAssetImage does not exist, not adding data");
     }
     closeModal();

--- a/frontend/src/components/buttons/FrameButton/FrameButton.module.scss
+++ b/frontend/src/components/buttons/FrameButton/FrameButton.module.scss
@@ -12,6 +12,7 @@
   text-align: right;
   width: fit-content;
   min-width: 98px;
+  box-sizing: border-box;
 
   &.icon {
     span {

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
@@ -17,6 +17,7 @@
 
 .button {
   width: 100%;
+  box-sizing: border-box;
 }
 
 .dropdown {

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -1,4 +1,5 @@
 @import "../../../styles/Colors.module.scss";
+@import url("https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;1,100;1,300;1,400;1,500;1,700&display=swap");
 
 @media (min-width: 900px) {
   .searchBaseInput {
@@ -35,6 +36,8 @@
   max-height: 400px;
   transition: height ease-out 0.2s;
   z-index: 1;
+  // the box-sizing has to be set again to counteract SFCC styling
+  box-sizing: border-box;
 
   &.open {
     height: 500px;

--- a/frontend/src/components/layouts/Modal.module.scss
+++ b/frontend/src/components/layouts/Modal.module.scss
@@ -2,15 +2,16 @@
   align-items: center;
   backdrop-filter: blur(10px);
   background-color: rgba(51, 51, 51, 0.3);
+  bottom: 0;
   display: flex;
   justify-content: center;
   left: 0;
+  max-height: 100%;
+  position: absolute;
   right: 0;
   top: 0;
-  bottom: 0;
   transition-delay: 200ms;
   transition: all 100ms cubic-bezier(0.4, 0, 0.2, 1);
-  position: absolute;
 
   & .modal-content {
     transform: translateY(100px);
@@ -36,7 +37,9 @@
   border-radius: 2px;
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
   box-sizing: border-box;
-  max-height: 80%;
+  max-height: 100%;
+  margin-top: 5%;
+  margin-bottom: 5%;
   min-height: 50px;
   padding: 20px;
   width: 95vw;

--- a/frontend/src/components/layouts/Portal.tsx
+++ b/frontend/src/components/layouts/Portal.tsx
@@ -15,6 +15,14 @@ export default function Portal({
 }: PortalProps) {
   const portalWrapper = React.useMemo(() => document.createElement("div"), []);
 
+  // Prevent background scroll
+  React.useEffect(() => {
+    document.body.style.overflowY = "hidden";
+    return () => {
+      document.body.style.overflowY = "auto";
+    };
+  }, []);
+
   React.useEffect(() => {
     const targetNode =
       container && container.appendChild ? container : document.body;

--- a/frontend/src/stories/extension/products.module.scss
+++ b/frontend/src/stories/extension/products.module.scss
@@ -35,7 +35,7 @@
 }
 
 .textarea {
-  background-color: #fff !important;
+  background-color: #fff;
   background-image: none;
   border: 1px solid #a5aeb5;
   padding: 1px 0 2px 2px;
@@ -47,4 +47,13 @@
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
+}
+
+// Simulate the SFCC box-sizing behavior
+.borderBoxInitial {
+  *,
+  *:before,
+  *:after {
+    box-sizing: content-box;
+  }
 }

--- a/frontend/src/stories/extension/products.stories.tsx
+++ b/frontend/src/stories/extension/products.stories.tsx
@@ -1,7 +1,6 @@
 import { ComponentMeta } from "@storybook/react";
 import React from "react";
 import { injectExtensionAppWithInterval } from "../../index-extension";
-import "../../styles/App.css";
 import styles from "./products.module.scss";
 
 export const SFImgixProductsSection = () => {
@@ -91,6 +90,7 @@ export const SFImgixProductsSection = () => {
 
 const NoExtensionTemplate = () => (
   <div
+    className={styles.borderBoxInitial}
     style={{
       width: "90%",
       margin: "64px 5%",


### PR DESCRIPTION
This PR overrides SFCC `box-sizing: content-box` to be `border-box`. This is necessary at the component level because they have several css-resets that counteract our App-scoped stylesheets.

## Video
[box-sizing-before.mov](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/76d43741-984c-48a6-b829-cc69d4f427bf/box-sizing-before.mov)

[box-sizing-after.mov](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/d98ba5e1-6e0b-47c5-8120-5f6f07c64580/box-sizing-after.mov)