### PR TITLE
feat: send selected id on click if it exists

### DIFF
--- a/frontend/src/components/ActionBar/ActionBar.module.scss
+++ b/frontend/src/components/ActionBar/ActionBar.module.scss
@@ -1,0 +1,22 @@
+.container {
+  margin: 20px auto auto auto;
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-flow: row nowrap;
+  justify-content: flex-end;
+}
+
+.buttons {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-flow: row nowrap;
+  justify-content: space-around;
+  width: 250px;
+  span {
+    margin-left: 5px;
+  }
+}

--- a/frontend/src/components/ActionBar/ActionBar.tsx
+++ b/frontend/src/components/ActionBar/ActionBar.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { FrameButton } from "../buttons/FrameButton/FrameButton";
+import { AddSvg } from "../icons";
+import styles from "./ActionBar.module.scss";
+
+export type IActionBarProps = {
+  disabled: boolean;
+  onSave: () => void;
+  onCancel: () => void;
+};
+
+export default function ActionBar({
+  disabled,
+  onSave,
+  onCancel,
+}: IActionBarProps) {
+  return (
+    <div className={styles.container}>
+      <div className={styles.buttons}>
+        <FrameButton label="Cancel" onClick={onCancel} />
+        <FrameButton
+          disabled={disabled}
+          color="secondary"
+          icon={<AddSvg />}
+          label="Save Image"
+          onClick={onSave}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ExtensionApp.module.scss
+++ b/frontend/src/components/ExtensionApp.module.scss
@@ -1,0 +1,9 @@
+// SFCC rem is not set to 16px. This breaks our typography.
+// We need to set size to 16px in order to use the correct font size.
+.fontSizeOverride {
+  *,
+  *:before,
+  *:after {
+    font-size: 16px;
+  }
+}

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -7,6 +7,7 @@ import "../styles/App.css";
 import { IBreakoutAppData } from "../types/breakoutAppPublic";
 import ActionBar from "./ActionBar/ActionBar";
 import { AssetBrowserContainer } from "./AssetBrowser/AssetBrowserContainer";
+import styles from "./ExtensionApp.module.scss";
 import { Modal } from "./layouts/Modal";
 import { ProductPageImages } from "./ProductPageImages";
 
@@ -120,7 +121,7 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
   const disabled = images === undefined || images.length === 0;
 
   return (
-    <div className="App">
+    <div className={styles.fontSizeOverride}>
       <header className="App-header">
         <div>
           <Modal
@@ -130,15 +131,17 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
             }}
             open={isModalOpen}
           >
-            <AssetBrowserContainer
-              apiKey={apiKey}
-              onSelectAsset={onSelectAsset}
-            />
-            <ActionBar
-              disabled={selectedAssetImage === undefined}
-              onSave={saveSelectionToDataOnClick}
-              onCancel={closeModalAndResetSelectedAssetImage}
-            />
+            <div className={styles.fontSizeOverride}>
+              <AssetBrowserContainer
+                apiKey={apiKey}
+                onSelectAsset={onSelectAsset}
+              />
+              <ActionBar
+                disabled={selectedAssetImage === undefined}
+                onSave={saveSelectionToDataOnClick}
+                onCancel={closeModalAndResetSelectedAssetImage}
+              />
+            </div>
           </Modal>
           <ProductPageImages
             onClick={onProductImageClick}

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -110,9 +110,6 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
       console.log("[imgix] adding asset to product images");
       const newImages = [...productImages, selectedAssetImage];
       updateProductImages(newImages);
-    } else {
-      // TODO: this _should_ be dead code. Need to remove.
-      console.log("[imgix] selectedAssetImage does not exist, not adding data");
     }
     closeModal();
   };

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -24,6 +24,28 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
   const [selectedAssetImage, setSelectedAssetImage] = React.useState<
     IImgixCustomAttributeImage | undefined
   >(undefined);
+  const [productImages, setProductImages] = React.useState<
+    IImgixCustomAttributeImage[]
+  >([]);
+
+  React.useEffect(() => {
+    if (data) {
+      // We store the products images in a local state
+      // so we can use it in the ProductPageImages component
+      // to accurately display the state of the product images
+      // json as it changes.
+      setProductImages(data.images || []);
+    }
+  }, [data]);
+
+  const updateProductImages = (
+    newProductImages: IImgixCustomAttributeImage[]
+  ) => {
+    setProductImages(newProductImages);
+    onChange({
+      images: newProductImages,
+    });
+  };
 
   const openModal = () => {
     console.info("[imgix] open imgix modal");
@@ -55,23 +77,23 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
     if (selectedProductImageId && selectedAssetImage) {
       console.log("[imgix] selectedAssetImage exists, replacing data");
       // for image with matching id, replace the image with the selected asset
-      const newImages = data?.images.map((image) => {
+      const newImages = productImages.map((image) => {
         if (image.imgix_metadata?.id === selectedProductImageId) {
           return selectedAssetImage;
         }
         return image;
       });
-      onChange({ images: newImages || [] });
+      updateProductImages(newImages || []);
     } else if (selectedAssetImage) {
       console.log("[imgix] asset selected, adding to data");
-      const newImages = data?.images.concat(selectedAssetImage);
-      onChange({ images: newImages || [] });
+      const newImages = productImages.concat(selectedAssetImage);
+      updateProductImages(newImages || []);
     } else {
       console.log("[imgix] selectedAssetImage does not exist, not adding data");
     }
   };
 
-  const images = data?.images || [];
+  const images = productImages || [];
   const disabled = images === undefined || images.length === 0;
 
   return (
@@ -93,7 +115,7 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
           </Modal>
           <ProductPageImages
             onClick={onProductImageClick}
-            images={images}
+            images={productImages}
             disabled={disabled}
           />
         </div>

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -86,8 +86,19 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
       updateProductImages(newImages || []);
     } else if (selectedAssetImage) {
       console.log("[imgix] asset selected, adding to data");
-      const newImages = productImages.concat(selectedAssetImage);
-      updateProductImages(newImages || []);
+      // if image id already exists, do nothing
+      if (
+        productImages.find(
+          (image) =>
+            image.imgix_metadata?.id === selectedAssetImage.imgix_metadata?.id
+        )
+      ) {
+        return;
+      } else {
+        // otherwise, add the image to the data
+        const newImages = [...productImages, selectedAssetImage];
+        updateProductImages(newImages);
+      }
     } else {
       console.log("[imgix] selectedAssetImage does not exist, not adding data");
     }

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -1,24 +1,78 @@
 import React from "react";
-import { IImgixCustomAttribute } from "../../../types";
+import {
+  IImgixCustomAttribute,
+  IImgixCustomAttributeImage,
+} from "../../../types";
 import "../styles/App.css";
+import { IBreakoutAppData } from "../types/breakoutAppPublic";
 import { AssetBrowserContainer } from "./AssetBrowser/AssetBrowserContainer";
+import { FrameButton } from "./buttons/FrameButton/FrameButton";
 import { Modal } from "./layouts/Modal";
 import { ProductPageImages } from "./ProductPageImages";
 
 export type ISidebarAppProps = {
-  onChange: (value: string) => void;
+  onChange: (data: IImgixCustomAttribute) => void;
   apiKey: string | null;
   data: IImgixCustomAttribute | undefined;
 };
 
 export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
-  const images = data?.images || [];
-  const disabled = images === undefined || images.length === 0;
-  const onOpenBreakoutClick = () => {
-    console.log("[imgix] open imgix modal");
+  const [selectedProductImageId, setSelectedProductImageId] = React.useState(
+    ""
+  );
+  const [selectedAssetImage, setSelectedAssetImage] = React.useState<
+    IImgixCustomAttributeImage | undefined
+  >(undefined);
+
+  const openModal = () => {
+    console.info("[imgix] open imgix modal");
     setIsModalOpen(true);
   };
+
+  const onProductImageClick = (id: string) => {
+    console.log("[imgix] onProductImageClick id:", id);
+
+    setSelectedProductImageId(id);
+    openModal();
+  };
+
+  const onSelectAsset = (assetData: IBreakoutAppData) => {
+    const { src, imgix_metadata: metadata } = { ...assetData };
+
+    const newImage = {
+      src,
+      imgix_metadata: metadata,
+      // SFCC requires all images have a alt/title attributes
+      title: metadata.attributes.name || metadata.attributes.origin_path,
+      alt: metadata.attributes.name || metadata.attributes.origin_path,
+    };
+
+    setSelectedAssetImage(newImage);
+  };
+
+  const saveSelectionToDataOnClick = () => {
+    if (selectedProductImageId && selectedAssetImage) {
+      console.log("[imgix] selectedAssetImage exists, replacing data");
+      // for image with matching id, replace the image with the selected asset
+      const newImages = data?.images.map((image) => {
+        if (image.imgix_metadata?.id === selectedProductImageId) {
+          return selectedAssetImage;
+        }
+        return image;
+      });
+      onChange({ images: newImages || [] });
+    } else if (selectedAssetImage) {
+      console.log("[imgix] asset selected, adding to data");
+      const newImages = data?.images.concat(selectedAssetImage);
+      onChange({ images: newImages || [] });
+    } else {
+      console.log("[imgix] selectedAssetImage does not exist, not adding data");
+    }
+  };
+
+  const images = data?.images || [];
+  const disabled = images === undefined || images.length === 0;
 
   return (
     <div className="App">
@@ -31,10 +85,14 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
             }}
             open={isModalOpen}
           >
-            <AssetBrowserContainer apiKey={apiKey} />
+            <AssetBrowserContainer
+              apiKey={apiKey}
+              onSelectAsset={onSelectAsset}
+            />
+            <FrameButton label="save" onClick={saveSelectionToDataOnClick} />
           </Modal>
           <ProductPageImages
-            onClick={onOpenBreakoutClick}
+            onClick={onProductImageClick}
             images={images}
             disabled={disabled}
           />

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -30,10 +30,10 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
     setIsModalOpen(true);
   };
 
-  const onProductImageClick = (id: string) => {
+  const onProductImageClick = (id?: string) => {
     console.log("[imgix] onProductImageClick id:", id);
 
-    setSelectedProductImageId(id);
+    setSelectedProductImageId(id || "");
     openModal();
   };
 

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -5,8 +5,8 @@ import {
 } from "../../../types";
 import "../styles/App.css";
 import { IBreakoutAppData } from "../types/breakoutAppPublic";
+import ActionBar from "./ActionBar/ActionBar";
 import { AssetBrowserContainer } from "./AssetBrowser/AssetBrowserContainer";
-import { FrameButton } from "./buttons/FrameButton/FrameButton";
 import { Modal } from "./layouts/Modal";
 import { ProductPageImages } from "./ProductPageImages";
 
@@ -49,7 +49,18 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
 
   const openModal = () => {
     console.info("[imgix] open imgix modal");
+    setSelectedAssetImage(undefined);
     setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    console.info("[imgix] close imgix modal");
+    setIsModalOpen(false);
+  };
+
+  const closeModalAndResetSelectedAssetImage = () => {
+    setSelectedAssetImage(undefined);
+    closeModal();
   };
 
   const onProductImageClick = (id?: string) => {
@@ -102,6 +113,7 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
     } else {
       console.log("[imgix] selectedAssetImage does not exist, not adding data");
     }
+    closeModal();
   };
 
   const images = productImages || [];
@@ -122,7 +134,11 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
               apiKey={apiKey}
               onSelectAsset={onSelectAsset}
             />
-            <FrameButton label="save" onClick={saveSelectionToDataOnClick} />
+            <ActionBar
+              disabled={selectedAssetImage === undefined}
+              onSave={saveSelectionToDataOnClick}
+              onCancel={closeModalAndResetSelectedAssetImage}
+            />
           </Modal>
           <ProductPageImages
             onClick={onProductImageClick}

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -81,14 +81,23 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
       title: metadata.attributes.name || metadata.attributes.origin_path,
       alt: metadata.attributes.name || metadata.attributes.origin_path,
     };
-
-    setSelectedAssetImage(newImage);
+    // If selected image already in data, set selectedAssetImage to undefined.
+    // This will disable the add-image button.
+    if (
+      productImages.find(
+        (image) => image.imgix_metadata?.id === newImage.imgix_metadata?.id
+      )
+    ) {
+      setSelectedAssetImage(undefined);
+    } else {
+      setSelectedAssetImage(newImage);
+    }
   };
 
   const saveSelectionToDataOnClick = () => {
     if (selectedProductImageId && selectedAssetImage) {
-      console.log("[imgix] selectedAssetImage exists, replacing data");
-      // for image with matching id, replace the image with the selected asset
+      console.log("[imgix] replacing product image");
+      // replace product image with selected asset image
       const newImages = productImages.map((image) => {
         if (image.imgix_metadata?.id === selectedProductImageId) {
           return selectedAssetImage;
@@ -97,21 +106,12 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
       });
       updateProductImages(newImages || []);
     } else if (selectedAssetImage) {
-      console.log("[imgix] asset selected, adding to data");
-      // if image id already exists, do nothing
-      if (
-        productImages.find(
-          (image) =>
-            image.imgix_metadata?.id === selectedAssetImage.imgix_metadata?.id
-        )
-      ) {
-        return;
-      } else {
-        // otherwise, add the image to the data
-        const newImages = [...productImages, selectedAssetImage];
-        updateProductImages(newImages);
-      }
+      // add product image to data
+      console.log("[imgix] adding asset to product images");
+      const newImages = [...productImages, selectedAssetImage];
+      updateProductImages(newImages);
     } else {
+      // TODO: this _should_ be dead code. Need to remove.
       console.log("[imgix] selectedAssetImage does not exist, not adding data");
     }
     closeModal();

--- a/frontend/src/components/ProductImage/ProductImageContainer.module.scss
+++ b/frontend/src/components/ProductImage/ProductImageContainer.module.scss
@@ -1,5 +1,9 @@
 @import "../../styles/Colors.module.scss";
 
+.contentWrapper {
+  display: flex;
+}
+
 .imageWrapper {
   background-color: $color_bg_new;
   overflow: hidden;

--- a/frontend/src/components/ProductImage/ProductImageContainer.tsx
+++ b/frontend/src/components/ProductImage/ProductImageContainer.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from "react";
 import { IImgixCustomAttributeImage } from "../../../../types";
-import { FrameButton } from "../buttons/FrameButton/FrameButton";
 import { ReplaceButton } from "../buttons/ReplaceButton";
 import { AssetCard } from "../card/AssetCard";
 import { Divider } from "../dividers/Divider";
@@ -27,7 +26,7 @@ export const ProductImageContainer = ({
   };
 
   return (
-    <div style={{ minWidth: 342, display: "flex" }}>
+    <div className={styles.contentWrapper}>
       <div
         className={styles.imageWrapper}
         onClick={() => onOpenBreakoutClick(image.imgix_metadata?.id)}
@@ -41,20 +40,6 @@ export const ProductImageContainer = ({
           asset={image?.imgix_metadata}
           domain={image?.imgix_metadata?.base_url || ""}
         />
-      </div>
-      <div className={styles.assetButtonsContainer}>
-        <div className={styles.assetButtons}>
-          <FrameButton size="small" color="primary" />
-          <p>Large</p>
-        </div>
-        <div className={styles.assetButtons}>
-          <FrameButton size="small" color="primary" />
-          <p>Medium</p>
-        </div>
-        <div className={styles.assetButtons}>
-          <FrameButton size="small" color="primary" />
-          <p>Small</p>
-        </div>
       </div>
       <Divider vertical />
     </div>

--- a/frontend/src/components/ProductImage/ProductImageContainer.tsx
+++ b/frontend/src/components/ProductImage/ProductImageContainer.tsx
@@ -8,7 +8,7 @@ import { Overlay } from "../layouts/Overlay";
 import styles from "./ProductImageContainer.module.scss";
 
 interface Props {
-  onOpenBreakoutClick: () => void;
+  onOpenBreakoutClick: (id: string) => void;
   image: IImgixCustomAttributeImage;
 }
 
@@ -30,7 +30,7 @@ export const ProductImageContainer = ({
     <div style={{ minWidth: 342, display: "flex" }}>
       <div
         className={styles.imageWrapper}
-        onClick={onOpenBreakoutClick}
+        onClick={() => onOpenBreakoutClick(image.imgix_metadata?.id || "")}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       >

--- a/frontend/src/components/ProductImage/ProductImageContainer.tsx
+++ b/frontend/src/components/ProductImage/ProductImageContainer.tsx
@@ -8,7 +8,7 @@ import { Overlay } from "../layouts/Overlay";
 import styles from "./ProductImageContainer.module.scss";
 
 interface Props {
-  onOpenBreakoutClick: (id: string) => void;
+  onOpenBreakoutClick: (id?: string) => void;
   image: IImgixCustomAttributeImage;
 }
 
@@ -30,7 +30,7 @@ export const ProductImageContainer = ({
     <div style={{ minWidth: 342, display: "flex" }}>
       <div
         className={styles.imageWrapper}
-        onClick={() => onOpenBreakoutClick(image.imgix_metadata?.id || "")}
+        onClick={() => onOpenBreakoutClick(image.imgix_metadata?.id)}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       >

--- a/frontend/src/components/ProductPageImages.module.scss
+++ b/frontend/src/components/ProductPageImages.module.scss
@@ -11,7 +11,7 @@
   min-width: 200px;
   overflow: hidden;
   margin: 2px;
-  padding-top: 84px;
+  padding: 0px;
 
   &:hover {
     box-shadow: 0 0 0 2px $color_fg;
@@ -19,5 +19,8 @@
 
   &:active {
     box-shadow: 0 0 0 2px $color_fg_tint2;
+  }
+  button {
+    margin-top: 84px;
   }
 }

--- a/frontend/src/components/ProductPageImages.tsx
+++ b/frontend/src/components/ProductPageImages.tsx
@@ -10,7 +10,7 @@ import styles from "./ProductPageImages.module.scss";
 export interface ProductPageImagesProps {
   disabled: boolean;
   images: IImgixCustomAttributeImage[] | undefined;
-  onClick: (id: string) => void;
+  onClick: (id?: string) => void;
 }
 
 export const ProductPageImages = ({
@@ -30,7 +30,7 @@ export const ProductPageImages = ({
           onClick={(e) => {
             // prevent form submission
             e.preventDefault();
-            onClick("");
+            onClick();
           }}
         />
       </div>

--- a/frontend/src/components/ProductPageImages.tsx
+++ b/frontend/src/components/ProductPageImages.tsx
@@ -10,7 +10,7 @@ import styles from "./ProductPageImages.module.scss";
 export interface ProductPageImagesProps {
   disabled: boolean;
   images: IImgixCustomAttributeImage[] | undefined;
-  onClick: () => void;
+  onClick: (id: string) => void;
 }
 
 export const ProductPageImages = ({
@@ -27,6 +27,11 @@ export const ProductPageImages = ({
           color="tertiary"
           className={styles.addImageButton}
           icon={<AddSvg />}
+          onClick={(e) => {
+            // prevent form submission
+            e.preventDefault();
+            onClick("");
+          }}
         />
       </div>
       <Divider vertical />

--- a/frontend/src/components/buttons/FrameButton/FrameButton.module.scss
+++ b/frontend/src/components/buttons/FrameButton/FrameButton.module.scss
@@ -12,6 +12,7 @@
   text-align: right;
   width: fit-content;
   min-width: 98px;
+  box-sizing: border-box;
 
   &.icon {
     span {

--- a/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
+++ b/frontend/src/components/buttons/dropdowns/SourceSelect.module.scss
@@ -17,6 +17,7 @@
 
 .button {
   width: 100%;
+  box-sizing: border-box;
 }
 
 .dropdown {

--- a/frontend/src/components/card/AssetCard.module.scss
+++ b/frontend/src/components/card/AssetCard.module.scss
@@ -29,6 +29,7 @@
   position: relative;
   overflow: hidden;
   height: 154px;
+  min-width: 200px;
 
   & img {
     display: block;

--- a/frontend/src/components/forms/search/SearchBar.module.scss
+++ b/frontend/src/components/forms/search/SearchBar.module.scss
@@ -1,4 +1,5 @@
 @import "../../../styles/Colors.module.scss";
+@import url("https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;1,100;1,300;1,400;1,500;1,700&display=swap");
 
 @media (min-width: 900px) {
   .searchBaseInput {
@@ -35,6 +36,8 @@
   max-height: 400px;
   transition: height ease-out 0.2s;
   z-index: 1;
+  // the box-sizing has to be set again to counteract SFCC styling
+  box-sizing: border-box;
 
   &.open {
     height: 500px;

--- a/frontend/src/components/layouts/Modal.module.scss
+++ b/frontend/src/components/layouts/Modal.module.scss
@@ -2,15 +2,16 @@
   align-items: center;
   backdrop-filter: blur(10px);
   background-color: rgba(51, 51, 51, 0.3);
+  bottom: 0;
   display: flex;
   justify-content: center;
   left: 0;
+  max-height: 100%;
+  position: absolute;
   right: 0;
   top: 0;
-  bottom: 0;
   transition-delay: 200ms;
   transition: all 100ms cubic-bezier(0.4, 0, 0.2, 1);
-  position: absolute;
 
   & .modal-content {
     transform: translateY(100px);
@@ -36,7 +37,9 @@
   border-radius: 2px;
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
   box-sizing: border-box;
-  max-height: 80%;
+  max-height: 100%;
+  margin-top: 5%;
+  margin-bottom: 5%;
   min-height: 50px;
   padding: 20px;
   width: 95vw;

--- a/frontend/src/components/layouts/Portal.tsx
+++ b/frontend/src/components/layouts/Portal.tsx
@@ -15,6 +15,14 @@ export default function Portal({
 }: PortalProps) {
   const portalWrapper = React.useMemo(() => document.createElement("div"), []);
 
+  // Prevent background scroll
+  React.useEffect(() => {
+    document.body.style.overflowY = "hidden";
+    return () => {
+      document.body.style.overflowY = "auto";
+    };
+  }, []);
+
   React.useEffect(() => {
     const targetNode =
       container && container.appendChild ? container : document.body;

--- a/frontend/src/index-extension.tsx
+++ b/frontend/src/index-extension.tsx
@@ -48,7 +48,8 @@ export const injectExtensionApp = () => {
     customAttributeTextarea.value = value;
   };
 
-  const customAttributeValue = JSON.parse(customAttributeTextarea.value);
+  const customAttrTextAreaValue = customAttributeTextarea.value || "{}";
+  const customAttributeValue = JSON.parse(customAttrTextAreaValue);
 
   const data = {
     images: customAttributeValue.images || [],

--- a/frontend/src/index-extension.tsx
+++ b/frontend/src/index-extension.tsx
@@ -1,4 +1,5 @@
 import ReactDOM from "react-dom";
+import { IImgixCustomAttribute } from "../../types";
 import { ExtensionApp } from "./components/ExtensionApp";
 import styles from "./index-extension.module.scss";
 
@@ -41,7 +42,8 @@ export const injectExtensionApp = () => {
    * Set the imgix custom attribute value.
    * @param value The stringified JSON value to set in the custom attribute textarea
    */
-  const setCustomAttributeValue = (value: string) => {
+  const setCustomAttributeValue = (data: IImgixCustomAttribute) => {
+    const value = JSON.stringify(data);
     // TODO: check correct way to set textarea value
     customAttributeTextarea.value = value;
   };

--- a/frontend/src/index-extension.tsx
+++ b/frontend/src/index-extension.tsx
@@ -53,7 +53,6 @@ export const injectExtensionApp = () => {
 
   const data = {
     images: customAttributeValue.images || [],
-    swatches: customAttributeValue?.swatches,
   };
 
   browser?.storage?.sync.get(

--- a/frontend/src/stories/extension/products.module.scss
+++ b/frontend/src/stories/extension/products.module.scss
@@ -35,7 +35,7 @@
 }
 
 .textarea {
-  background-color: #fff !important;
+  background-color: #fff;
   background-image: none;
   border: 1px solid #a5aeb5;
   padding: 1px 0 2px 2px;
@@ -47,4 +47,13 @@
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
+}
+
+// Simulate the SFCC box-sizing behavior
+.borderBoxInitial {
+  *,
+  *:before,
+  *:after {
+    box-sizing: content-box;
+  }
 }

--- a/frontend/src/stories/extension/products.stories.tsx
+++ b/frontend/src/stories/extension/products.stories.tsx
@@ -1,7 +1,6 @@
 import { ComponentMeta } from "@storybook/react";
 import React from "react";
 import { injectExtensionAppWithInterval } from "../../index-extension";
-import "../../styles/App.css";
 import styles from "./products.module.scss";
 
 export const SFImgixProductsSection = () => {
@@ -91,6 +90,7 @@ export const SFImgixProductsSection = () => {
 
 const NoExtensionTemplate = () => (
   <div
+    className={styles.borderBoxInitial}
     style={{
       width: "90%",
       margin: "64px 5%",


### PR DESCRIPTION
This PR updates the type definitions and implementations of `openBreakoutOnClick` and `ProductPageImage` `onClick` to allow for the `id` optional argument.