### PR TITLE
fix: fallback to SF images when custom attribute array is empty

### DIFF
--- a/src/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.ts
+++ b/src/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.ts
@@ -54,6 +54,11 @@ function Images(
     return undefined;
   })();
 
+  const hasCustomImages: boolean = Boolean(
+    imgixCustomAttributeData?.images &&
+      imgixCustomAttributeData.images.length > 0
+  );
+
   /* The next section operates in one of three modes:
    * 1. if custom attribute data exists, use that to render the images (as this
    *    overrides the built-in SF data)
@@ -61,7 +66,11 @@ function Images(
    * 3. fallback to the built-in SF data
    */
 
-  if (imgixEnableProductImageProxy && imgixCustomAttributeData) {
+  if (
+    imgixEnableProductImageProxy &&
+    imgixCustomAttributeData &&
+    hasCustomImages
+  ) {
     // 1. custom attribute data exists
 
     imageConfig.types.forEach(function (
@@ -72,7 +81,7 @@ function Images(
         if (imageConfig.quantity === "single") {
           return imgixCustomAttributeData.images.slice(0, 1);
         }
-        return imgixCustomAttributeData.images
+        return imgixCustomAttributeData.images;
       })();
 
       const result = images.map((image, index) => {

--- a/test/unit/int_imgix_products_sfra/models/product/productImages.js
+++ b/test/unit/int_imgix_products_sfra/models/product/productImages.js
@@ -47,8 +47,16 @@ var images = new ArrayList([
   },
 ]);
 var customData = {
-  imgixData:
-    '{"images": [{"src": "customImgixURL/imgix_first_image_url", "title": "First Image title", "alt": "First Image alt"}, {"src": "customImgixURL/imgix_second_image_url","sourceWidth": 3000}]}',
+  imgixData: JSON.stringify({
+    images: [
+      {
+        src: "customImgixURL/imgix_first_image_url",
+        title: "First Image title",
+        alt: "First Image alt",
+      },
+      { src: "customImgixURL/imgix_second_image_url", sourceWidth: 3000 },
+    ],
+  }),
 };
 
 var productMock = {
@@ -275,6 +283,24 @@ describe("ProductImages model", function () {
 
     it("should still work when imgixBaseURL preference is not set");
     it("should set default params on images");
+
+    it("should fallback to SF images with empty custom images array", function () {
+      var product = new Product({
+        customData: JSON.stringify({
+          imgixData: {
+            images: [],
+          },
+        }),
+      });
+      var images = new ProductImages(product, {
+        types: ["small"],
+        quantity: "single",
+      });
+      assert.equal(images.small[0].alt, "First Image alt");
+      assert.equal(images.small[0].title, "First Image title");
+      assert.equal(images.small[0].index, "0");
+      assert.equal(images.small[0].url, "imgixBaseURL/sf_first_image_url");
+    });
   });
 
   describe("without custom attribute", () => {


### PR DESCRIPTION
Before this PR, if the imgix custom attribute in the products data was an empty array (and not just simply an empty string), the model would not return any images. Now the model will fallback to the SF images if no custom attribute images exist.
