### PR TITLE
chore(extension): update to manifest v3

### DIFF
--- a/frontend/src/index-extension.tsx
+++ b/frontend/src/index-extension.tsx
@@ -100,8 +100,8 @@ export const injectExtensionAppWithInterval = () => {
 };
 
 export const runExtension = () => {
-  browser.extension.sendMessage({}, function (response: any) {
-    var readyStateCheckInterval = setInterval(function () {
+  browser.runtime.sendMessage({}, () => {
+    const readyStateCheckInterval = setInterval(function () {
       if (document.readyState === "complete") {
         clearInterval(readyStateCheckInterval);
 

--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "imgix Salesforce B2C Commerce Cloud Extension",
   "version": "0.0.1",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "description": "This extension provides a Salesforce Commerce Cloud B2C integration with imgix.",
   "homepage_url": "https://imgix.com",
   "icons": {
@@ -9,7 +9,7 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["https://*.salesforce.com/*", "storage"],
+  "permissions": ["storage"],
   "content_scripts": [
     {
       "matches": ["https://*.salesforce.com/*ViewProduct_52*"],


### PR DESCRIPTION
This PR updates the Browser extension to work with Chrome manifest v3. This is required to submit to the Chrome Web Store. I ran through a whole workflow (setting API key -> adding image to product -> checking image renders on PDP) but I recommend that this be tested by a third party as well. (Be sure to `yarn deploy:extension` before testing!)

NB: host_permissions is not needed since in v3 content_scripts are automatically added to host_permissions
