### PR TITLE
feat: add delete button to proudct images

### DIFF
--- a/frontend/src/components/ExtensionApp.module.scss
+++ b/frontend/src/components/ExtensionApp.module.scss
@@ -7,3 +7,11 @@
     font-size: 16px;
   }
 }
+
+.boxSizingOverride {
+  *,
+  *:before,
+  *:after {
+    box-sizing: border-box;
+  }
+}

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -64,7 +64,10 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
     closeModal();
   };
 
-  const onProductImageClick = (type: "delete" | "add", id?: string) => {
+  const onProductImageClick = (
+    type: "delete" | "replace" | "add",
+    id?: string
+  ) => {
     console.log(`[imgix] onProductImageClick - id: ${id} type: ${type}`);
 
     // if type is "delete"

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -128,7 +128,7 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
   const disabled = images === undefined || images.length === 0;
 
   return (
-    <div className={styles.fontSizeOverride}>
+    <div className={`${styles.fontSizeOverride} ${styles.boxSizingOverride}`}>
       <header className="App-header">
         <div>
           <Modal
@@ -138,7 +138,9 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
             }}
             open={isModalOpen}
           >
-            <div className={styles.fontSizeOverride}>
+            <div
+              className={`${styles.fontSizeOverride} ${styles.boxSizingOverride}`}
+            >
               <AssetBrowserContainer
                 apiKey={apiKey}
                 onSelectAsset={onSelectAsset}

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -64,8 +64,18 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
     closeModal();
   };
 
-  const onProductImageClick = (id?: string) => {
-    console.log("[imgix] onProductImageClick id:", id);
+  const onProductImageClick = (type: "delete" | "add", id?: string) => {
+    console.log(`[imgix] onProductImageClick - id: ${id} type: ${type}`);
+
+    // if type is "delete"
+    if (type === "delete") {
+      // remove the image from the productImages array
+      const newProductImages = productImages.filter(
+        (image) => image.imgix_metadata?.id !== id
+      );
+      updateProductImages(newProductImages);
+      return;
+    }
 
     setSelectedProductImageId(id || "");
     openModal();

--- a/frontend/src/components/ProductImage/ProductImageContainer.module.scss
+++ b/frontend/src/components/ProductImage/ProductImageContainer.module.scss
@@ -26,7 +26,8 @@
   margin-left: -6.5rem;
   margin-top: -9rem;
   width: 90px;
-  button {
+  .button {
     box-sizing: border-box;
+    cursor: pointer;
   }
 }

--- a/frontend/src/components/ProductImage/ProductImageContainer.module.scss
+++ b/frontend/src/components/ProductImage/ProductImageContainer.module.scss
@@ -17,26 +17,16 @@
   color: $color_invert_fg;
 }
 
-.assetButtonsContainer {
-  align-items: center;
+.buttonContainer {
+  position: relative;
   display: flex;
-  flex-direction: column;
-  font-size: $type_size_small;
-  justify-content: space-between;
-  padding-left: 5px;
-  padding-right: 30px;
-
-  .assetButtons {
-    align-items: center;
-    display: flex;
-    flex-direction: row;
-    font-size: $type_size_small;
-    justify-content: space-between;
-    padding: 10px 0 10px 0px;
-    width: 70px;
-
-    p {
-      margin-left: 10px;
-    }
+  flex-direction: row;
+  justify-content: space-evenly;
+  box-sizing: border-box;
+  margin-left: -6.5rem;
+  margin-top: -9rem;
+  width: 90px;
+  button {
+    box-sizing: border-box;
   }
 }

--- a/frontend/src/components/ProductImage/ProductImageContainer.tsx
+++ b/frontend/src/components/ProductImage/ProductImageContainer.tsx
@@ -1,8 +1,9 @@
 import React, { ReactElement } from "react";
 import { IImgixCustomAttributeImage } from "../../../../types";
-import { ReplaceButton } from "../buttons/ReplaceButton";
+import { FrameButton } from "../buttons/FrameButton/FrameButton";
 import { AssetCard } from "../card/AssetCard";
 import { Divider } from "../dividers/Divider";
+import { DeleteIcon, RefreshSvg } from "../icons";
 import { Overlay } from "../layouts/Overlay";
 import styles from "./ProductImageContainer.module.scss";
 
@@ -33,7 +34,20 @@ export const ProductImageContainer = ({
         onMouseLeave={onMouseLeave}
       >
         <Overlay rounded visible={hovering}>
-          <ReplaceButton label="REPLACE" />
+          <div className={styles.buttonContainer}>
+            <FrameButton
+              className={styles.button}
+              color="tertiary"
+              icon={<DeleteIcon />}
+              onClick={() => onClick("delete", image.imgix_metadata?.id)}
+            />
+            <FrameButton
+              className={styles.button}
+              color="tertiary"
+              icon={<RefreshSvg />}
+              onClick={() => onClick("add", image.imgix_metadata?.id)}
+            />
+          </div>
         </Overlay>
         <AssetCard
           asset={image?.imgix_metadata}

--- a/frontend/src/components/ProductImage/ProductImageContainer.tsx
+++ b/frontend/src/components/ProductImage/ProductImageContainer.tsx
@@ -7,13 +7,13 @@ import { Overlay } from "../layouts/Overlay";
 import styles from "./ProductImageContainer.module.scss";
 
 interface Props {
-  onOpenBreakoutClick: (id?: string) => void;
+  onClick: (type: "delete" | "add", id?: string) => void;
   image: IImgixCustomAttributeImage;
 }
 
 export const ProductImageContainer = ({
   image,
-  onOpenBreakoutClick,
+  onClick,
 }: Props): ReactElement => {
   const [hovering, setHovering] = React.useState(false);
 
@@ -29,7 +29,6 @@ export const ProductImageContainer = ({
     <div className={styles.contentWrapper}>
       <div
         className={styles.imageWrapper}
-        onClick={() => onOpenBreakoutClick(image.imgix_metadata?.id)}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       >

--- a/frontend/src/components/ProductImage/ProductImageContainer.tsx
+++ b/frontend/src/components/ProductImage/ProductImageContainer.tsx
@@ -8,7 +8,7 @@ import { Overlay } from "../layouts/Overlay";
 import styles from "./ProductImageContainer.module.scss";
 
 interface Props {
-  onClick: (type: "delete" | "add", id?: string) => void;
+  onClick: (type: "delete" | "replace" | "add", id?: string) => void;
   image: IImgixCustomAttributeImage;
 }
 
@@ -35,18 +35,22 @@ export const ProductImageContainer = ({
       >
         <Overlay rounded visible={hovering}>
           <div className={styles.buttonContainer}>
-            <FrameButton
-              className={styles.button}
-              color="tertiary"
-              icon={<DeleteIcon />}
-              onClick={() => onClick("delete", image.imgix_metadata?.id)}
-            />
-            <FrameButton
-              className={styles.button}
-              color="tertiary"
-              icon={<RefreshSvg />}
-              onClick={() => onClick("add", image.imgix_metadata?.id)}
-            />
+            <div data-testid="asset-card-delete-button">
+              <FrameButton
+                className={styles.button}
+                color="tertiary"
+                icon={<DeleteIcon />}
+                onClick={() => onClick("delete", image.imgix_metadata?.id)}
+              />
+            </div>
+            <div data-testid="asset-card-replace-button">
+              <FrameButton
+                className={styles.button}
+                color="tertiary"
+                icon={<RefreshSvg />}
+                onClick={() => onClick("replace", image.imgix_metadata?.id)}
+              />
+            </div>
           </div>
         </Overlay>
         <AssetCard

--- a/frontend/src/components/ProductPageImages.module.scss
+++ b/frontend/src/components/ProductPageImages.module.scss
@@ -6,21 +6,15 @@
   justify-self: stretch;
   background: $color_invert_fg;
   border-radius: 4px;
-  cursor: pointer;
+  // cursor: pointer;
   min-height: 200px;
   min-width: 200px;
   overflow: hidden;
   margin: 2px;
   padding: 0px;
 
-  &:hover {
-    box-shadow: 0 0 0 2px $color_fg;
-  }
-
-  &:active {
-    box-shadow: 0 0 0 2px $color_fg_tint2;
-  }
   button {
     margin-top: 84px;
+    cursor: pointer;
   }
 }

--- a/frontend/src/components/ProductPageImages.module.scss
+++ b/frontend/src/components/ProductPageImages.module.scss
@@ -6,7 +6,6 @@
   justify-self: stretch;
   background: $color_invert_fg;
   border-radius: 4px;
-  // cursor: pointer;
   min-height: 200px;
   min-width: 200px;
   overflow: hidden;

--- a/frontend/src/components/ProductPageImages.tsx
+++ b/frontend/src/components/ProductPageImages.tsx
@@ -10,7 +10,7 @@ import styles from "./ProductPageImages.module.scss";
 export interface ProductPageImagesProps {
   disabled: boolean;
   images: IImgixCustomAttributeImage[] | undefined;
-  onClick: (type: "delete" | "add", id?: string) => void;
+  onClick: (type: "delete" | "replace" | "add", id?: string) => void;
 }
 
 export const ProductPageImages = ({

--- a/frontend/src/components/ProductPageImages.tsx
+++ b/frontend/src/components/ProductPageImages.tsx
@@ -10,7 +10,7 @@ import styles from "./ProductPageImages.module.scss";
 export interface ProductPageImagesProps {
   disabled: boolean;
   images: IImgixCustomAttributeImage[] | undefined;
-  onClick: (id?: string) => void;
+  onClick: (type: "delete" | "add", id?: string) => void;
 }
 
 export const ProductPageImages = ({
@@ -30,7 +30,7 @@ export const ProductPageImages = ({
           onClick={(e) => {
             // prevent form submission
             e.preventDefault();
-            onClick();
+            onClick("add");
           }}
         />
       </div>
@@ -40,10 +40,7 @@ export const ProductPageImages = ({
         typescript will throw an error */}
         {images?.map((image: IImgixCustomAttributeImage) => {
           return (
-            <ProductImageContainer
-              onOpenBreakoutClick={onClick}
-              image={{ ...image }}
-            />
+            <ProductImageContainer onClick={onClick} image={{ ...image }} />
           );
         })}
       </>

--- a/frontend/src/tests/extensionApp/extension_App.test.tsx
+++ b/frontend/src/tests/extensionApp/extension_App.test.tsx
@@ -65,14 +65,19 @@ describe("extension", () => {
     expect(screen.getByText("Select a Source")).toBeInTheDocument();
   });
 
-  test("should open modal when replace button is clicked", async () => {
+  test("should open IM modal when replace button is clicked", async () => {
     render(<WithExtension />);
 
+    // hover over asset card
     await waitFor(() => {
       const assetCard = screen.getByText("amsterdam.jpg");
       fireEvent.mouseOver(assetCard);
+    });
 
-      const replaceButton = screen.getByTestId("asset-card-replace-button");
+    // click replace button
+    await waitFor(() => {
+      const replaceButton = screen.getByTestId("asset-card-replace-button")
+        .children[0];
       fireEvent.click(replaceButton);
     });
 

--- a/frontend/src/tests/extensionApp/extension_App.test.tsx
+++ b/frontend/src/tests/extensionApp/extension_App.test.tsx
@@ -83,4 +83,24 @@ describe("extension", () => {
 
     expect(screen.getByText("Select a Source")).toBeInTheDocument();
   });
+
+  test("should remove image when delete button is clicked", async () => {
+    render(<WithExtension />);
+
+    // hover over asset card
+    await waitFor(() => {
+      const assetCard = screen.getByText("amsterdam.jpg");
+
+      fireEvent.mouseOver(assetCard);
+    });
+
+    // click delete button
+    await waitFor(() => {
+      const deleteButton = screen.getByTestId("asset-card-delete-button")
+        .children[0];
+      fireEvent.click(deleteButton);
+    });
+
+    expect(document.querySelectorAll("img").length).toBe(0);
+  });
 });


### PR DESCRIPTION
## Before this PR
- There was no delete button
- The replace button did not match the comps
- the box-sizing was getting overridden by sfcc

## After this PR
- delete buttons added
- replace button matches comps
- box-sizing no longer gets overridden


## Screenshots
![delete-button-after.png](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/3bae87ab-27a1-4931-8b38-3c99b817e1d1/delete-button-after.png)

## Video
[delete-replace-video.mov](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/0cdb2930-0cb2-4e5d-be9d-bab43d32d149/delete-replace-video.mov)