### PR TITLE
fix: ensure hover goes away on modal open

### DIFF
--- a/frontend/src/components/ProductImage/ProductImageContainer.tsx
+++ b/frontend/src/components/ProductImage/ProductImageContainer.tsx
@@ -48,7 +48,10 @@ export const ProductImageContainer = ({
                 className={styles.button}
                 color="tertiary"
                 icon={<RefreshSvg />}
-                onClick={() => onClick("replace", image.imgix_metadata?.id)}
+                onClick={() => {
+                  setHovering(false);
+                  onClick("replace", image.imgix_metadata?.id);
+                }}
               />
             </div>
           </div>


### PR DESCRIPTION
Before this commit, it was possible for the asset-card hover styles to
still be visible even after the modal was opened.