### PR TITLE
test: feed dev api key on local builds

### DIFF
--- a/frontend/src/index-extension.tsx
+++ b/frontend/src/index-extension.tsx
@@ -3,6 +3,9 @@ import { IImgixCustomAttribute } from "../../types";
 import { ExtensionApp } from "./components/ExtensionApp";
 import styles from "./index-extension.module.scss";
 
+// read the environment variable
+const DEVELOPMENT_API_KEY = process.env.IMGIX_API_KEY || undefined;
+
 // extend the window type to include browser key as any
 declare global {
   interface Window {
@@ -73,7 +76,7 @@ export const injectExtensionApp = () => {
   ) ||
     ReactDOM.render(
       <ExtensionApp
-        apiKey={""}
+        apiKey={DEVELOPMENT_API_KEY || ""}
         data={data}
         onChange={setCustomAttributeValue}
       />,


### PR DESCRIPTION
## Before this PR
Storybook and tests did not have access to a testing API key in the extension.

## After this PR
A testing API key is automatically inserted into the extension


In order for this to work, there needs to be a `.env` file inside `/src` to read the `IMGIX_API_KEY` from.