### PR TITLE
test: add data-testid to source-select button

### DIFF
--- a/frontend/src/components/buttons/SourceSelectButton.tsx
+++ b/frontend/src/components/buttons/SourceSelectButton.tsx
@@ -38,7 +38,12 @@ export const SourceSelectButton = ({
       >
         <SourceMenuSvg />
       </div>
-      <div className={styles.label}>{label}</div>
+      <div
+        data-testid={`source-select-button-label-${label}`}
+        className={styles.label}
+      >
+        {label}
+      </div>
       <div className={styles.spacer}></div>
       <div
         className={


### PR DESCRIPTION
This commit adds a label-specific data-testid to the source-select
button. This was done this way to ensure we could wait for the selected
source label to populate inside of the tests.