### PR TITLE
test: source automcatiicaly requested on render

### DIFF
--- a/frontend/src/stories/extension/products.stories.tsx
+++ b/frontend/src/stories/extension/products.stories.tsx
@@ -55,7 +55,7 @@ export const SFImgixProductsSection = () => {
                       {JSON.stringify({
                         images: [
                           {
-                            src: "https://sdk-test.imgix.net/amsterdam.jpg",
+                            src: "https://assets.imgix.net/sam-test/cub.jpg",
                             view_type: {
                               large: true,
                               medium: true,
@@ -63,14 +63,14 @@ export const SFImgixProductsSection = () => {
                             },
                             imgix_metadata: {
                               attributes: {
-                                description: "amsterdam",
-                                name: "/amsterdam.jpg",
-                                origin_path: "/amsterdam.jpg",
+                                description: "cub",
+                                name: "/cub.jpg",
+                                origin_path: "/sam-test/cub.jpg",
                                 media_height: 0,
                                 media_width: 0,
                               },
-                              base_url: "sdk-test.imgix.net",
-                              id: "1",
+                              base_url: "assets.imgix.net",
+                              id: "51f0282eadfe543b14000003/sam-test/cub.jpg",
                               type: "assets",
                             },
                           },

--- a/frontend/src/tests/extensionApp/extension_App.test.tsx
+++ b/frontend/src/tests/extensionApp/extension_App.test.tsx
@@ -37,7 +37,7 @@ describe("extension", () => {
     render(<WithExtension />);
 
     await waitFor(() => {
-      expect(screen.getByText("amsterdam.jpg")).toBeInTheDocument();
+      expect(screen.getByText("cub.jpg")).toBeInTheDocument();
     });
   });
 
@@ -45,7 +45,7 @@ describe("extension", () => {
     render(<WithExtension />);
 
     await waitFor(() => {
-      const assetCard = screen.getByText("amsterdam.jpg");
+      const assetCard = screen.getByText("cub.jpg");
       fireEvent.mouseOver(assetCard);
       screen.getByTestId("asset-card-replace-button");
     });
@@ -70,7 +70,7 @@ describe("extension", () => {
 
     // hover over asset card
     await waitFor(() => {
-      const assetCard = screen.getByText("amsterdam.jpg");
+      const assetCard = screen.getByText("cub.jpg");
       fireEvent.mouseOver(assetCard);
     });
 
@@ -81,15 +81,46 @@ describe("extension", () => {
       fireEvent.click(replaceButton);
     });
 
-    expect(screen.getByText("Select a Source")).toBeInTheDocument();
+    expect(screen.getByText("Save Image")).toBeInTheDocument();
   });
+
+  test("should auto-select source when replace button is clicked", async () => {
+    render(<WithExtension />);
+
+    // hover over asset card
+    await waitFor(() => {
+      const assetCard = screen.getByText("cub.jpg");
+      fireEvent.mouseOver(assetCard);
+    });
+
+    // click replace button
+    await waitFor(() => {
+      const replaceButton = screen.getByTestId("asset-card-replace-button")
+        .children[0];
+      fireEvent.click(replaceButton);
+    });
+
+    await waitFor(
+      () => {
+        screen.getByTestId("source-select-button-label-assets");
+      },
+      // had to increase timeout to account for hitting the actual API
+      { timeout: 2000 }
+    );
+
+    const selectedSource = screen.getByTestId(
+      "source-select-button-label-assets"
+    );
+
+    expect(selectedSource.innerHTML).toBe("assets");
+  }, 11000);
 
   test("should remove image when delete button is clicked", async () => {
     render(<WithExtension />);
 
     // hover over asset card
     await waitFor(() => {
-      const assetCard = screen.getByText("amsterdam.jpg");
+      const assetCard = screen.getByText("cub.jpg");
 
       fireEvent.mouseOver(assetCard);
     });


### PR DESCRIPTION
This PR adds tests that ensure, whenever an image is being replaced, it's source is automatically set in the source dropdown.

This PR also updates the test custom attribute JSON to match the expected values from the source more closely.