### PR TITLE
feat: create attribute-form component

### DIFF
--- a/frontend/src/components/ActionBar/ActionBar.module.scss
+++ b/frontend/src/components/ActionBar/ActionBar.module.scss
@@ -1,11 +1,14 @@
+@import "../../styles/Colors.module.scss";
 .container {
-  margin: 20px auto auto auto;
+  padding: 20px 0px 20px 0px;
+  background: $color_bg;
   position: relative;
   display: flex;
   flex-direction: row;
   align-items: center;
   flex-flow: row nowrap;
   justify-content: flex-end;
+  height: auto;
 }
 
 .buttons {

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -8,7 +8,7 @@ import { IBreakoutAppData } from "../types/breakoutAppPublic";
 import ActionBar from "./ActionBar/ActionBar";
 import { AssetBrowserContainer } from "./AssetBrowser/AssetBrowserContainer";
 import styles from "./ExtensionApp.module.scss";
-import { AttributeForm } from "./forms/attributes/AttributeForm";
+import { AttributeFormContainer } from "./forms/attributes/AttributeFormContainer";
 import { Modal } from "./layouts/Modal";
 import { ProductPageImages } from "./ProductPageImages";
 
@@ -209,8 +209,8 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
             <div
               className={`${styles.fontSizeOverride} ${styles.boxSizingOverride}`}
             >
-              <AttributeForm
-                asset={selectedProductImage || undefined}
+              <AttributeFormContainer
+                asset={selectedProductImage}
                 onSubmit={setProductImageAttributes}
                 onCancel={() => setIsAttributeEditorOpen(false)}
               />

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -65,7 +65,7 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
   };
 
   const onProductImageClick = (
-    type: "delete" | "replace" | "add",
+    type: "delete" | "replace" | "add" | "edit",
     id?: string
   ) => {
     console.log(`[imgix] onProductImageClick - id: ${id} type: ${type}`);

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -216,11 +216,15 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
               />
             </div>
           </Modal>
-          <ProductPageImages
-            onClick={onProductImageClick}
-            images={productImages}
-            disabled={disabled}
-          />
+          <div
+            className={`${styles.fontSizeOverride} ${styles.boxSizingOverride}`}
+          >
+            <ProductPageImages
+              onClick={onProductImageClick}
+              images={productImages}
+              disabled={disabled}
+            />
+          </div>
         </div>
       </header>
     </div>

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -52,6 +52,10 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
     });
   };
 
+  const closeAttributeEditor = () => {
+    setIsAttributeEditorOpen(false);
+  };
+
   const openModal = (type: "assets" | "attributes" = "assets") => {
     console.info("[imgix] open imgix modal");
     if (type === "assets") {
@@ -66,7 +70,7 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
     if (type === "assets") {
       setIsModalOpen(false);
     } else if (type === "attributes") {
-      setIsAttributeEditorOpen(false);
+      closeAttributeEditor();
     }
   };
 
@@ -167,7 +171,7 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
         }
       });
       updateProductImages(newImages);
-      setIsAttributeEditorOpen(false);
+      closeAttributeEditor();
     }
   };
 
@@ -201,9 +205,7 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
           {/* AttributeEditor Modal */}
           <Modal
             locked={true}
-            onClose={() => {
-              setIsAttributeEditorOpen(false);
-            }}
+            onClose={closeAttributeEditor}
             open={isAttributeEditorOpen}
           >
             <div
@@ -212,7 +214,7 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
               <AttributeFormContainer
                 asset={selectedProductImage}
                 onSubmit={setProductImageAttributes}
-                onCancel={() => setIsAttributeEditorOpen(false)}
+                onCancel={closeAttributeEditor}
               />
             </div>
           </Modal>

--- a/frontend/src/components/ProductImage/ProductImageContainer.module.scss
+++ b/frontend/src/components/ProductImage/ProductImageContainer.module.scss
@@ -23,9 +23,9 @@
   flex-direction: row;
   justify-content: space-evenly;
   box-sizing: border-box;
-  margin-left: -6.5rem;
-  margin-top: -9rem;
-  width: 90px;
+  margin-left: -4rem;
+  margin-top: -9.5rem;
+  width: 135px;
   .button {
     box-sizing: border-box;
     cursor: pointer;

--- a/frontend/src/components/ProductImage/ProductImageContainer.module.scss
+++ b/frontend/src/components/ProductImage/ProductImageContainer.module.scss
@@ -23,8 +23,8 @@
   flex-direction: row;
   justify-content: space-evenly;
   box-sizing: border-box;
-  margin-left: -4rem;
-  margin-top: -9.5rem;
+  margin-left: -64px;
+  margin-top: -150px;
   width: 135px;
   .button {
     box-sizing: border-box;

--- a/frontend/src/components/ProductImage/ProductImageContainer.tsx
+++ b/frontend/src/components/ProductImage/ProductImageContainer.tsx
@@ -4,6 +4,7 @@ import { FrameButton } from "../buttons/FrameButton/FrameButton";
 import { AssetCard } from "../card/AssetCard";
 import { Divider } from "../dividers/Divider";
 import { DeleteIcon, RefreshSvg } from "../icons";
+import { MetaSvg } from "../icons/MetaSvg";
 import { Overlay } from "../layouts/Overlay";
 import styles from "./ProductImageContainer.module.scss";
 
@@ -51,6 +52,17 @@ export const ProductImageContainer = ({
                 onClick={() => {
                   setHovering(false);
                   onClick("replace", image.imgix_metadata?.id);
+                }}
+              />
+            </div>
+            <div data-testid="asset-card-edit-button">
+              <FrameButton
+                className={styles.button}
+                color="tertiary"
+                icon={<MetaSvg />}
+                onClick={() => {
+                  setHovering(false);
+                  onClick("edit", image.imgix_metadata?.id);
                 }}
               />
             </div>

--- a/frontend/src/components/ProductImage/ProductImageContainer.tsx
+++ b/frontend/src/components/ProductImage/ProductImageContainer.tsx
@@ -8,7 +8,7 @@ import { Overlay } from "../layouts/Overlay";
 import styles from "./ProductImageContainer.module.scss";
 
 interface Props {
-  onClick: (type: "delete" | "replace" | "add", id?: string) => void;
+  onClick: (type: "delete" | "replace" | "add" | "edit", id?: string) => void;
   image: IImgixCustomAttributeImage;
 }
 

--- a/frontend/src/components/ProductPageImages.tsx
+++ b/frontend/src/components/ProductPageImages.tsx
@@ -10,7 +10,7 @@ import styles from "./ProductPageImages.module.scss";
 export interface ProductPageImagesProps {
   disabled: boolean;
   images: IImgixCustomAttributeImage[] | undefined;
-  onClick: (type: "delete" | "replace" | "add", id?: string) => void;
+  onClick: (type: "delete" | "replace" | "add" | "edit", id?: string) => void;
 }
 
 export const ProductPageImages = ({

--- a/frontend/src/components/forms/attributes/AttributeForm.module.scss
+++ b/frontend/src/components/forms/attributes/AttributeForm.module.scss
@@ -1,0 +1,42 @@
+@import "../../../styles/Colors.module.scss";
+
+.formContainer {
+  padding: 24px;
+  border-top: 12px solid $color_accent_blue;
+  background-color: $color_bg;
+  width: 100%;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-top: 20px;
+
+  input {
+    border: 1px solid $color_chrome;
+    box-sizing: border-box;
+    border-radius: 4px;
+    margin: 15px 10px 15px 10px;
+    padding: 8px 10px 8px 10px;
+    color: $color_fg;
+    font-size: $type_size_small;
+  }
+
+  .formLabel {
+    display: flex;
+    flex-direction: row;
+    p {
+      margin-left: 10px;
+    }
+  }
+}
+
+.formButtons {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 24px;
+  button {
+    margin-left: 8px;
+  }
+}

--- a/frontend/src/components/forms/attributes/AttributeForm.tsx
+++ b/frontend/src/components/forms/attributes/AttributeForm.tsx
@@ -7,7 +7,7 @@ import { MetaSvg } from "../../icons/MetaSvg";
 import styles from "./AttributeForm.module.scss";
 
 type AttributeFormProps = {
-  asset: IImgixCustomAttributeImage | undefined;
+  asset: IImgixCustomAttributeImage;
   onSubmit: (attributes: { alt: string; title: string }) => void;
   onCancel: () => void;
 };
@@ -21,26 +21,35 @@ export function AttributeForm({
   const [title, setTitle] = React.useState("");
 
   React.useEffect(() => {
-    // set the alt and title on first render
-    if (asset) {
-      setAlt(asset.alt || "");
-      setTitle(asset.title || "");
-    }
+    /**
+     * Sets the alt and title on first render to the values of the asset
+     *
+     * By default the asset's alt and default to imgix_metadata.attributes.name
+     * or imgix_metadata.attributes.origin_path. This is because the SFCC
+     * requires that all images have alt/title attributes defined.
+     *
+     * In the unlikely event that the asset does not have an alt/title attribute
+     * defined, the alt/title values in the form will be set to an empty string.
+     *  */
+    setAlt(asset.alt || "");
+    setTitle(asset.title || "");
   }, [asset]);
+
+  const submitFormOnEnter = (event: React.KeyboardEvent<HTMLFormElement>) => {
+    if (event.key === "Enter") {
+      onSubmit({ alt, title });
+    }
+  };
 
   return (
     <div className={styles.formContainer}>
-      <form className={styles.form}>
+      <form className={styles.form} onKeyPress={submitFormOnEnter}>
         <label className={styles.formLabel}>
           <MetaSvg />
           <p>Alt text</p>
         </label>
         <input
           type="text"
-          // Extension will default to this if not provided.
-          // Important to surface this here to the user to make it
-          // clear what the default is.
-          // placeholder={placeholder}
           value={alt}
           onChange={(e) => setAlt(e.target.value)}
         />
@@ -50,7 +59,6 @@ export function AttributeForm({
         </label>
         <input
           type="text"
-          // placeholder={placeholder}
           value={title}
           onChange={(e) => setTitle(e.target.value)}
         />

--- a/frontend/src/components/forms/attributes/AttributeForm.tsx
+++ b/frontend/src/components/forms/attributes/AttributeForm.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { IImgixCustomAttributeImage } from "../../../../../types";
+import { FrameButton } from "../../buttons/FrameButton/FrameButton";
+import { ArrowRight, DisabledSvg } from "../../icons";
+import { ButtonListSvg } from "../../icons/ButtonListSvg";
+import { MetaSvg } from "../../icons/MetaSvg";
+import styles from "./AttributeForm.module.scss";
+
+type AttributeFormProps = {
+  asset: IImgixCustomAttributeImage | undefined;
+  onSubmit: (attributes: { alt: string; title: string }) => void;
+  onCancel: () => void;
+};
+
+export function AttributeForm({
+  asset,
+  onSubmit,
+  onCancel,
+}: AttributeFormProps) {
+  const [alt, setAlt] = React.useState("");
+  const [title, setTitle] = React.useState("");
+
+  React.useEffect(() => {
+    // set the alt and title on first render
+    if (asset) {
+      setAlt(asset.alt || "");
+      setTitle(asset.title || "");
+    }
+  }, [asset]);
+
+  return (
+    <div className={styles.formContainer}>
+      <form className={styles.form}>
+        <label className={styles.formLabel}>
+          <MetaSvg />
+          <p>Alt text</p>
+        </label>
+        <input
+          type="text"
+          // Extension will default to this if not provided.
+          // Important to surface this here to the user to make it
+          // clear what the default is.
+          // placeholder={placeholder}
+          value={alt}
+          onChange={(e) => setAlt(e.target.value)}
+        />
+        <label className={styles.formLabel}>
+          <ButtonListSvg />
+          <p>Title</p>
+        </label>
+        <input
+          type="text"
+          // placeholder={placeholder}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+      </form>
+      <div className={styles.formButtons}>
+        <FrameButton
+          icon={<DisabledSvg />}
+          color="primary"
+          label={"Cancel"}
+          onClick={() => onCancel()}
+        />
+        <FrameButton
+          icon={<ArrowRight />}
+          color="secondary"
+          label={"Accept"}
+          onClick={() => onSubmit({ alt, title })}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/forms/attributes/AttributeFormContainer.tsx
+++ b/frontend/src/components/forms/attributes/AttributeFormContainer.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { IImgixCustomAttributeImage } from "../../../../../types";
+import { AttributeForm } from "./AttributeForm";
+
+type Props = {
+  asset: IImgixCustomAttributeImage | undefined;
+  onSubmit: (attributes: { alt: string; title: string }) => void;
+  onCancel: () => void;
+};
+
+export function AttributeFormContainer({ asset, onSubmit, onCancel }: Props) {
+  if (!asset) {
+    return null;
+  }
+  return (
+    <AttributeForm asset={asset} onSubmit={onSubmit} onCancel={onCancel} />
+  );
+}

--- a/frontend/src/components/icons/ButtonListSvg.tsx
+++ b/frontend/src/components/icons/ButtonListSvg.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import styles from "./Icon.module.scss";
+
+export const ButtonListSvg = ({ className }: { className?: string }) => (
+  <div className={`${styles.container} ${className ? className : ""}`}>
+    <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+      <g>
+        <path d="M4 1H0V5H4V1Z" />
+        <path d="M4 6H0V10H4V6Z" />
+        <path d="M4 11H0V15H4V11Z" />
+        <path d="M16 2H6V4H16V2Z" />
+        <path d="M16 7H6V9H16V7Z" />
+        <path d="M16 12H6V14H16V12Z" />
+      </g>
+    </svg>
+  </div>
+);

--- a/frontend/src/components/layouts/Modal.module.scss
+++ b/frontend/src/components/layouts/Modal.module.scss
@@ -33,9 +33,9 @@
 }
 
 .content {
-  background-color: white;
+  // background-color: white;
   border-radius: 2px;
-  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+  // box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
   box-sizing: border-box;
   max-height: 100%;
   margin-top: 5%;

--- a/frontend/src/components/layouts/Modal.module.scss
+++ b/frontend/src/components/layouts/Modal.module.scss
@@ -33,9 +33,7 @@
 }
 
 .content {
-  // background-color: white;
   border-radius: 2px;
-  // box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
   box-sizing: border-box;
   max-height: 100%;
   margin-top: 5%;


### PR DESCRIPTION
This PR creates the `AttributeForm` component that opens as a modal inside the extension. This component allows you to set/update the `alt` and `title` attributes of a selected image.

This PR also creates the `ButtonList` icon.

This PR also includes some small styling adjustments to account for the `rem` value for SFCC bot being `16px`.

## Video
[alt-title-settings.mov](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/50754f26-b91f-4949-8117-8ba9610c2899/alt-title-settings.mov)