### PR TITLE
feat: search on enter keypress

### DIFF
--- a/frontend/src/components/buttons/FrameButton/FrameButton.tsx
+++ b/frontend/src/components/buttons/FrameButton/FrameButton.tsx
@@ -11,6 +11,7 @@ type Props = {
   label?: string;
   noFill?: boolean;
   size?: "small" | "large";
+  type?: "button" | "submit" | "reset";
   onClick?: React.MouseEventHandler<HTMLButtonElement> | undefined;
 };
 
@@ -24,6 +25,7 @@ export function FrameButton({
   label,
   noFill,
   size = "large",
+  type = "button",
   onClick,
 }: Props) {
   // if label is not provided, display a button with only the icon
@@ -42,12 +44,22 @@ export function FrameButton({
     .toString()
     .replace(/,/g, " ");
   return iconPosition === "left" ? (
-    <button className={buttonStyles} disabled={disabled} onClick={onClick}>
+    <button
+      type={type}
+      className={buttonStyles}
+      disabled={disabled}
+      onClick={onClick}
+    >
       {icon}
       {label && <span className={styles.label}>{label}</span>}
     </button>
   ) : (
-    <button className={buttonStyles} disabled={disabled} onClick={onClick}>
+    <button
+      type={type}
+      className={buttonStyles}
+      disabled={disabled}
+      onClick={onClick}
+    >
       {label && <span className={styles.label}>{label}</span>}
       {icon}
     </button>

--- a/frontend/src/components/buttons/FrameButton/FrameButton.tsx
+++ b/frontend/src/components/buttons/FrameButton/FrameButton.tsx
@@ -12,7 +12,7 @@ type Props = {
   noFill?: boolean;
   size?: "small" | "large";
   type?: "button" | "submit" | "reset";
-  onClick?: React.MouseEventHandler<HTMLButtonElement> | undefined;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
 };
 
 export function FrameButton({

--- a/frontend/src/components/forms/search/SearchBar.tsx
+++ b/frontend/src/components/forms/search/SearchBar.tsx
@@ -48,7 +48,6 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
     const searchTerm = suggestedSearch || query;
     handleSubmit(searchTerm);
     updateSearchHistory(searchTerm);
-    setQuery("");
     setIsVisible(false);
   };
 
@@ -104,6 +103,7 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
         >
           <div className={styles.searchButtons}>
             <FrameButton
+              type="button"
               noFill
               size="small"
               className={styles.clear}
@@ -112,6 +112,7 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
               onClick={handleInputClear}
             />
             <FrameButton
+              type="submit"
               noFill
               color="secondary"
               size="small"


### PR DESCRIPTION
## Before this PR
Could not press enter to search for images

## After this PR
- FrameButton now accepts a `type` prop that allows it to set its behavior to 'button | reset | submit'.
- You can now press 'enter' to search

## Video
[search-on-enter.mov](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/e5dcf8dc-a486-44f8-a106-c361ba89a080/search-on-enter.mov)