### PR TITLE
chore: display grid items with fixed ar

### DIFF
--- a/frontend/src/components/AssetBrowser/AssetBrowser.module.scss
+++ b/frontend/src/components/AssetBrowser/AssetBrowser.module.scss
@@ -1,7 +1,6 @@
 .assetBrowser {
   flex: 1 1 auto;
   background-color: #eef0f2;
-  padding-bottom: 16px;
   display: flex;
   flex-direction: column;
   min-height: 730px;
@@ -20,7 +19,7 @@
 }
 .assetGridContainer {
   flex: 1 1 auto;
-  padding: 32px 16px;
+  padding: 16px 16px 0px 16px;
 }
 .paginationContainer {
   display: flex;

--- a/frontend/src/components/ProductImage/ProductImageContainer.module.scss
+++ b/frontend/src/components/ProductImage/ProductImageContainer.module.scss
@@ -23,8 +23,7 @@
   flex-direction: row;
   justify-content: space-evenly;
   box-sizing: border-box;
-  margin-left: -64px;
-  margin-top: -150px;
+  margin-top: -95px;
   width: 135px;
   .button {
     box-sizing: border-box;

--- a/frontend/src/components/ProductPageImages.module.scss
+++ b/frontend/src/components/ProductPageImages.module.scss
@@ -6,14 +6,14 @@
   justify-self: stretch;
   background: $color_invert_fg;
   border-radius: 4px;
-  min-height: 200px;
-  min-width: 200px;
+  height: 134px;
+  width: 134px;
   overflow: hidden;
   margin: 2px;
   padding: 0px;
 
   button {
-    margin-top: 84px;
+    margin-top: 45px;
     cursor: pointer;
   }
 }

--- a/frontend/src/components/card/AssetCard.module.scss
+++ b/frontend/src/components/card/AssetCard.module.scss
@@ -1,7 +1,3 @@
-.grid {
-  grid-column: span 2;
-}
-
 .container {
   justify-self: stretch;
   background: #1c2c38;

--- a/frontend/src/components/card/AssetCard.module.scss
+++ b/frontend/src/components/card/AssetCard.module.scss
@@ -11,7 +11,6 @@
   border-radius: 4px;
   cursor: pointer;
   height: 136px;
-  width: 136px;
   aspect-ratio: 1/1;
   overflow: hidden;
 
@@ -33,7 +32,17 @@
   overflow: hidden;
   height: 136px;
 
-  & img {
+  [data-tooltip]:before {
+    position: absolute;
+    content: attr(data-tooltip);
+    opacity: 0;
+  }
+
+  [data-tooltip]:hover:before {
+    opacity: 1;
+  }
+
+  img {
     display: block;
     object-fit: cover;
     width: 100%;

--- a/frontend/src/components/card/AssetCard.module.scss
+++ b/frontend/src/components/card/AssetCard.module.scss
@@ -4,12 +4,19 @@
 
 .container {
   justify-self: stretch;
-  background: #fff;
+  background: #1c2c38;
+  background-image: linear-gradient(45deg, #16232d 25%, transparent 0),
+    linear-gradient(-45deg, #16232d 25%, transparent 0),
+    linear-gradient(45deg, transparent 75%, #16232d 0),
+    linear-gradient(-45deg, transparent 75%, #16232d 0);
+  background-size: 20px 20px;
+  background-position: 0 0, 0 10px, 10px -10px, 10px 0;
   border-radius: 2px;
   border-radius: 4px;
   cursor: pointer;
-  max-height: 200px;
-  max-width: 200px;
+  height: 136px;
+  width: 136px;
+  aspect-ratio: 1/1;
   overflow: hidden;
 
   &:hover {
@@ -28,14 +35,13 @@
 .image {
   position: relative;
   overflow: hidden;
-  height: 154px;
-  min-width: 200px;
+  height: 136px;
 
   & img {
     display: block;
     object-fit: cover;
     width: 100%;
-    height: 100%;
+    height: 100px;
   }
 }
 
@@ -52,6 +58,8 @@
    * one line */
   white-space: nowrap;
   position: relative;
+  top: -40px;
+  background: white;
   padding: 6px 10px;
   margin: 0px;
   text-align: center;
@@ -77,7 +85,7 @@
   background-size: 20px 20px;
   background-position: 0 0, 0 10px, 10px -10px, 10px 0;
   transition: none;
-  height: 154px;
+  height: 136px;
 }
 
 .disabled {

--- a/frontend/src/components/card/AssetCard.tsx
+++ b/frontend/src/components/card/AssetCard.tsx
@@ -31,6 +31,13 @@ export function AssetCard({
     /\.(avif|gif|jp2|jpg|jpeg|json|jxr|pjpg|png|png8|png32|webp|blurhash|svg|ai)$/
   );
 
+  // Split filename to be last 18 characters, the full filepath will be in the
+  // title attribute tooltip that is displayed on hover.
+  const truncatedFilename =
+    filename.length > 18
+      ? filename.slice(filename.length - 19, filename.length)
+      : filename;
+
   const containerStyles = [
     styles.container,
     layout === "list" ? styles.list : styles.grid,
@@ -53,7 +60,11 @@ export function AssetCard({
           <img alt="" src={placeholder} />
         </div>
       )}
-      {noFilepath ? null : <p className={styles.filename}>{filename}</p>}
+      {noFilepath ? null : (
+        <p title={asset?.attributes.origin_path} className={styles.filename}>
+          {truncatedFilename}
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/grids/AssetGrid.module.scss
+++ b/frontend/src/components/grids/AssetGrid.module.scss
@@ -1,5 +1,8 @@
+@import "../../styles/Colors.module.scss";
 .gridContainer {
   flex: 1 1 auto;
+  max-height: 700px;
+  overflow-y: scroll;
 }
 
 .gridItemPlaceholder {

--- a/frontend/src/components/grids/AssetGrid.module.scss
+++ b/frontend/src/components/grids/AssetGrid.module.scss
@@ -3,6 +3,12 @@
   flex: 1 1 auto;
   max-height: 700px;
   overflow-y: scroll;
+  padding: 4px;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
 }
 
 .gridItemPlaceholder {

--- a/frontend/src/components/image/AssetCardImage.tsx
+++ b/frontend/src/components/image/AssetCardImage.tsx
@@ -16,6 +16,10 @@ export function AssetCardImage({ asset, domain }: Props) {
         fit: "crop",
         crop: "entropy",
       }}
+      htmlAttributes={{
+        title: asset?.attributes.name || asset?.attributes.origin_path || "",
+        alt: asset?.attributes.name || asset?.attributes.origin_path || "",
+      }}
       /* This sizes attribute is a monster and sets the size of the image
        * correctly, handling both the SF breakpoints and the design
        * breakpoints

--- a/frontend/src/services/imgixAPIService.ts
+++ b/frontend/src/services/imgixAPIService.ts
@@ -67,7 +67,7 @@ export const imgixAPI = {
         apiKey: string,
         sourceId: string,
         index: string = "0",
-        size: string = "14"
+        size: string = "20"
       ) {
         // ?page[number]=${n}&page[size]=18`
         return await makeRequest<ImgixGETAssetsData>({
@@ -90,7 +90,7 @@ export const imgixAPI = {
       sourceId: string,
       query: string,
       index: string = "0",
-      size: string = "14"
+      size: string = "20"
     ) {
       // build the filter portion of the query
       const categories = `filter%5Bor:categories%5D=${query}`;

--- a/frontend/src/styles/Grid.css
+++ b/frontend/src/styles/Grid.css
@@ -6,32 +6,49 @@
 }
 
 .ix-grid {
-  display: grid;
-  grid-gap: 16px;
-  justify-items: stretch;
-  align-items: start;
-  grid-template-columns: repeat(14, 1fr);
-}
-@media (max-width: 960px) {
-  .ix-grid {
-    grid-template-columns: repeat(12, 1fr);
-  }
-}
+  /** 
+   * Have the grid automatically resize itself to fill its container _and_
+   * have the grid automatically resize its columns to fill the grid.
+   *
+   * Based off of this excellent article:
+   * https://css-tricks.com/an-auto-filling-css-grid-with-max-columns/
+   */
 
-@media (max-width: 820px) {
-  .ix-grid {
-    grid-template-columns: repeat(8, 1fr);
-  }
-}
-@media (max-width: 700px) {
-  .ix-grid {
-    grid-template-columns: repeat(6, 1fr);
-  }
-}
-@media (max-width: 500px) {
-  .ix-grid {
-    grid-template-columns: repeat(4, 1fr);
-  }
+  /**
+   * User input values.
+   */
+
+  --grid-layout-gap: 10px;
+  --grid-column-count: 14;
+  --grid-item--min-width: 134px;
+
+  /**
+   * Calculated values.
+   */
+
+  /* gapCount = columnCount - 1 */
+  --gap-count: calc(var(--grid-column-count) - 1);
+  /* totalGapWidth = gapCount * gapSize */
+  --total-gap-width: calc(var(--gap-count) * var(--grid-layout-gap));
+  /* gridItemMaxWidth = (containerWidth - gapWidth) / columnCount */
+  --grid-item--max-width: calc(
+    (100% - var(--total-gap-width)) / var(--grid-column-count)
+  );
+
+  display: grid;
+  grid-template-columns: repeat(
+    /* fill available columns without stretching the grid item */ auto-fill,
+    /* 
+     * gridItemWidth = max(minWidth, gridItemMaxWidth)
+     * gridColumnSize = minmax(gridItemWidth, 1 fraction of the available space)
+     *
+     * Where `minmax` returns size range greater than or equal to min and less
+     * than or equal to max. In this case, the grid item is constrained to be
+      * at least `gridItemWidth` and at most `1fr`.
+     */
+      minmax(max(var(--grid-item--min-width), var(--grid-item--max-width)), 1fr)
+  );
+  grid-gap: var(--grid-layout-gap);
 }
 
 .ix-grid-item {
@@ -41,7 +58,6 @@
   overflow: hidden;
   max-height: 340px;
   max-width: 340px;
-  grid-column: span 2;
   border-radius: 4px;
 }
 


### PR DESCRIPTION
## Before this PR
- The grid item would scretch to fill the available space
- Only 14 items were displayed at a time

## After this PR
- grid items have a fixed 1:1 aspect ratio
- 20 items are displayed at a time

## Video

### before

[grid-before.mov](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/eaf20676-43c0-4539-9e43-1e4a44f1dd89/grid-before.mov)

### after


https://user-images.githubusercontent.com/16711614/155194563-bd7eda79-96b6-4973-b1e2-92408d5de4f0.mov


