### PR TITLE
fix: ensure extension app doesnt affect layout

### DIFF
--- a/frontend/src/components/ExtensionApp.module.scss
+++ b/frontend/src/components/ExtensionApp.module.scss
@@ -15,3 +15,9 @@
     box-sizing: border-box;
   }
 }
+
+.productPageImagesContainer {
+  // This ensures that the x-overflow occurs when the products container is
+  // larger than 95vw - 1rem.
+  max-width: calc(95vw - 1rem);
+}

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -218,7 +218,9 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
           />
         </div>
       </Modal>
-      <div className={`${styles.fontSizeOverride} ${styles.boxSizingOverride}`}>
+      <div
+        className={`${styles.fontSizeOverride} ${styles.boxSizingOverride} ${styles.productPageImagesContainer}`}
+      >
         <ProductPageImages
           onClick={onProductImageClick}
           images={productImages}

--- a/frontend/src/index-extension.tsx
+++ b/frontend/src/index-extension.tsx
@@ -52,6 +52,8 @@ export const injectExtensionApp = () => {
 
   const newTable = document.createElement("table");
   const newTB = document.createElement("tbody");
+  // ensure newTB doesn't exceed viewport width
+  newTable.style.maxWidth = "100vw";
   const newTR = document.createElement("tr");
   const newTD = document.createElement("td");
 

--- a/frontend/src/index-extension.tsx
+++ b/frontend/src/index-extension.tsx
@@ -23,22 +23,48 @@ const browser = window.browser;
 
 const productsLabelSelector = '[data-dw-tooltip="Product.imgixData"]';
 export const injectExtensionApp = () => {
+  /**
+   * Note:
+   *
+   * We need to make a new table to hold the extension app
+   * because including the extension app in the same table
+   * as the imgix custom attribute textarea causes the other
+   * table rows to be shifted right as the extension app
+   * adds more images. This table _has_ to be outside the "root"
+   * table that holds the product attributes. Otherwise, the
+   * styling on the page is messed up.
+   *
+   */
+
   const productsLabel = document.querySelector(productsLabelSelector);
   const productsLabelParentTable = productsLabel?.closest("table");
   const closestTR = productsLabelParentTable?.closest("tr");
+  // The imgix custom attribute json
   const customAttributeTextarea = closestTR?.querySelector("textarea");
+  // Find and store the product attributes table for the imgix custom attribute
+  const productAttributesTable = productsLabelParentTable?.parentElement?.closest(
+    "table"
+  );
 
-  if (!closestTR || !customAttributeTextarea) {
+  if (!closestTR || !customAttributeTextarea || !productAttributesTable) {
     return;
   }
 
+  const newTable = document.createElement("table");
+  const newTB = document.createElement("tbody");
   const newTR = document.createElement("tr");
   const newTD = document.createElement("td");
+
   newTD.setAttribute("colspan", "2");
   newTD.setAttribute("class", styles.appContainer);
   newTR.appendChild(newTD);
+  newTB.appendChild(newTR);
+  newTable.appendChild(newTB);
 
-  closestTR.insertAdjacentElement("afterend", newTR);
+  // Add the new table with the extension app to the DOM
+  productAttributesTable?.insertAdjacentElement("afterend", newTable);
+
+  // keep the imgix custom attribute JSON from rendering but leave it editable
   closestTR.style.display = "none";
 
   /**

--- a/frontend/src/stories/extension/products.stories.tsx
+++ b/frontend/src/stories/extension/products.stories.tsx
@@ -9,7 +9,7 @@ export const SFImgixProductsSection = () => {
       <tbody>
         <tr>
           <td
-            className={`${styles.tableHeader} ${styles.aldi}`}
+            className={`${styles.tableHeader} ${styles.aldi} table_header`}
             colSpan={3}
             width="100%"
           >


### PR DESCRIPTION
## Before this PR

The extension app was being added to a table within a table within the product attributes table. This made it so that the other table/table rows on the page would expand to whatever size our product images table became.

## After this PR

A new table is added to the page outside of the product attributes table. This ensures layout is not affected as we add more and more images.

Since what's being submitted is only the custom attribute JSON, this change does not affect our ability to save the changes to the custom attribute.


## Screenshots

![layout-after-new-table.jpg](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/71bd84a0-6cb6-4d01-96a2-57b9da07a46c/layout-after-new-table.jpg)


## Video

https://user-images.githubusercontent.com/16711614/155224299-99de8ad1-73c9-44e0-8033-ae5e63da4747.mov


