### PR TITLE
fix: set search-term on search-history click

### DIFF
--- a/frontend/src/components/forms/search/SearchBar.tsx
+++ b/frontend/src/components/forms/search/SearchBar.tsx
@@ -48,6 +48,7 @@ export function SearchBar({ placeholder, handleSubmit }: Props): ReactElement {
     const searchTerm = suggestedSearch || query;
     handleSubmit(searchTerm);
     updateSearchHistory(searchTerm);
+    setQuery(searchTerm);
     setIsVisible(false);
   };
 


### PR DESCRIPTION
Before this commit, serach term in the serach bar would not update to
reflect the selected term from the history.

After this commit, the search term in the search bar updates to the
selected item.


## Video

https://user-images.githubusercontent.com/16711614/155264340-571e07dd-7682-4f83-a8e8-4c4507e01b34.mov


