### PR TITLE
feat: disable extension if product is locked

### DIFF
--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -35,9 +35,10 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
   const [locked, setLocked] = React.useState(false);
 
   React.useEffect(() => {
-    setLocked(
-      document.querySelector(".table_detail_link")?.textContent === "Lock"
-    );
+    // Set the extension to locked if the `.unlock_icon` class is present.
+    // This class is only present on the page when the SFCC product is locked.
+    // When it's unlocked, the class name changes to `lockedit_icon`.
+    setLocked(document.querySelector(".unlock_icon") !== null);
   }, []);
 
   React.useEffect(() => {

--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -32,6 +32,13 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
   const [isAttributeEditorOpen, setIsAttributeEditorOpen] = React.useState(
     false
   );
+  const [locked, setLocked] = React.useState(false);
+
+  React.useEffect(() => {
+    setLocked(
+      document.querySelector(".table_detail_link")?.textContent === "Lock"
+    );
+  }, []);
 
   React.useEffect(() => {
     if (data) {
@@ -148,7 +155,7 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
   };
 
   const images = productImages || [];
-  const disabled = images === undefined || images.length === 0;
+  const disabled = images === undefined || images.length === 0 || locked;
   const selectedSourceId = selectedProductImageId.split("/")[0];
   const selectedProductImage = images.find(
     (image) => image.imgix_metadata?.id === selectedProductImageId

--- a/frontend/src/components/ProductImage/ProductImageContainer.tsx
+++ b/frontend/src/components/ProductImage/ProductImageContainer.tsx
@@ -11,10 +11,12 @@ import styles from "./ProductImageContainer.module.scss";
 interface Props {
   onClick: (type: "delete" | "replace" | "add" | "edit", id?: string) => void;
   image: IImgixCustomAttributeImage;
+  disabled?: boolean;
 }
 
 export const ProductImageContainer = ({
   image,
+  disabled,
   onClick,
 }: Props): ReactElement => {
   const [hovering, setHovering] = React.useState(false);
@@ -38,6 +40,7 @@ export const ProductImageContainer = ({
           <div className={styles.buttonContainer}>
             <div data-testid="asset-card-delete-button">
               <FrameButton
+                disabled={disabled}
                 className={styles.button}
                 color="tertiary"
                 icon={<DeleteIcon />}
@@ -46,6 +49,7 @@ export const ProductImageContainer = ({
             </div>
             <div data-testid="asset-card-replace-button">
               <FrameButton
+                disabled={disabled}
                 className={styles.button}
                 color="tertiary"
                 icon={<RefreshSvg />}
@@ -57,6 +61,7 @@ export const ProductImageContainer = ({
             </div>
             <div data-testid="asset-card-edit-button">
               <FrameButton
+                disabled={disabled}
                 className={styles.button}
                 color="tertiary"
                 icon={<MetaSvg />}

--- a/frontend/src/components/ProductPageImages.tsx
+++ b/frontend/src/components/ProductPageImages.tsx
@@ -22,6 +22,7 @@ export const ProductPageImages = ({
     <OverflowScrollX>
       <div className={styles.addImageButtonContainer}>
         <FrameButton
+          disabled={disabled}
           frameless
           label="Add Image"
           color="tertiary"
@@ -40,7 +41,11 @@ export const ProductPageImages = ({
         typescript will throw an error */}
         {images?.map((image: IImgixCustomAttributeImage) => {
           return (
-            <ProductImageContainer onClick={onClick} image={{ ...image }} />
+            <ProductImageContainer
+              disabled={disabled}
+              onClick={onClick}
+              image={{ ...image }}
+            />
           );
         })}
       </>


### PR DESCRIPTION
This commit disabled the extension buttons if the product is `locked` on
SFCC. This ensures that the extension cannot be interacted with while
the product is locked.

It does this by storing a boolean tracking if the "Locked" label currently
reads as "Locked" or not.

This commit adds a `disabled` prop to the ProductImageContainer and
ProductPageImages components in order to achieve this.


## Video

https://user-images.githubusercontent.com/16711614/155265722-7815924a-70e9-47ea-9ad2-64c9586b5ddf.mov


