### PR TITLE
chore: fix help-text typos

### DIFF
--- a/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.json
+++ b/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.json
@@ -35,7 +35,7 @@
         {
           "id": "sizes",
           "name": "Sizes attribute",
-          "description": "The sizes attribute for the image to help the image behave responsibly. If the image is a fixed size, set this to the image width.",
+          "description": "The sizes attribute for the image to help the image behave responsively. If the image is a fixed size, set this to the image width.",
           "type": "string",
           "required": false
         },
@@ -56,7 +56,7 @@
         {
           "id": "fm",
           "name": "Format",
-          "description": "The format to apply to the image. It is recommended to use the auto parameter to set format, by including 'format' in the setting above. If set, this will override auto-formatting. For more information, see: https://docs.imgix.com/apis/rendering/format",
+          "description": "The format to apply to the image. It is recommended to use the auto parameter to set format, by including 'format' in the setting below. If set, this will override auto-formatting. For more information, see: https://docs.imgix.com/apis/rendering/format",
           "type": "string",
           "required": false
         },


### PR DESCRIPTION
This commit fixes a couple of typos in the help-text shown on hover in the Page Designer.

## Screen shots
![text-update-1.jpg](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/3f423fa6-fd64-4a69-8e8c-cec3164a5c14/text-update-1.jpg)
![text-update-2.jpg](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/57907011-7633-432b-bfa5-ef8a42e20c15/text-update-2.jpg)