### PR TITLE
fix: replace button icon color

### DIFF
--- a/frontend/src/components/SidebarApp.module.scss
+++ b/frontend/src/components/SidebarApp.module.scss
@@ -51,6 +51,9 @@
   height: 16px;
   width: 16px;
   margin-right: 4px;
+  svg {
+    fill: white;
+  }
 }
 
 .hr {


### PR DESCRIPTION
This commit ensures the button icon SVG is set to white. Before this
commit, the button icon was set to the incorrect color.

## Screenshot
![replace-button-icon-color.jpg](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/366a11b8-845b-48b4-a91e-aba765c30bc9/replace-button-icon-color.jpg)