### PR TITLE
fix: make sidebar img fill container width

### DIFF
--- a/frontend/src/components/SidebarApp.module.scss
+++ b/frontend/src/components/SidebarApp.module.scss
@@ -1,9 +1,14 @@
 .imageWrapper {
   background-color: #e3e7eb;
   height: 215px;
+  width: fit-content;
   overflow: hidden;
   display: flex;
   position: relative;
+
+  img {
+    width: 370px;
+  }
 }
 
 .replaceImageOverlay {

--- a/frontend/src/components/SidebarApp.tsx
+++ b/frontend/src/components/SidebarApp.tsx
@@ -61,7 +61,7 @@ export function App({
             </div>
             <Imgix
               src={value.src}
-              width={344}
+              width={370}
               height={215}
               imgixParams={{
                 fit: "crop",


### PR DESCRIPTION
Before this commit the sidebar image was not filling it's container,
leaving a small gap between the image and the right hand side.

## Screenshots
![sidebar-img-before.jpg](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/393a9284-e421-4192-b325-9e893568339e/sidebar-img-before.jpg)
![sidebar-img-after.jpg](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/b19bff91-4426-443d-ba7d-9ffec0887ed8/sidebar-img-after.jpg)