### PR TITLE
fix: ensure default-params never null

### DIFF
--- a/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
+++ b/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
@@ -26,8 +26,16 @@ module.exports.render = function (context, modelIn) {
   var model = modelIn || new HashMap();
   var content = context.content;
 
-  const defaultParams =
+  let defaultParams =
     Site.getCurrent().getCustomPreferenceValue("imgixDefaultParams");
+
+  // if default params string is empty or null, return empty string
+  if (!defaultParams) {
+    ImgixLogger.info(
+      "************************** imgix Image Component Not Provided Default Params"
+    );
+    defaultParams = "";
+  }
 
   const defaultParamsJSON = defaultParams.split("&").reduce(function (p, v) {
     const [queryParamKey, queryParamValue] = v.split("=");


### PR DESCRIPTION
## Before this commit
If the `defaultParams` custom config for page designer was left empty, no images would render in the page designer.

## After this commit
If the `defaultParams` are null they are set to an empty string, ensuring rendering doesn't break.
