### PR TITLE
fix(sidebar): set fixed width for image container

### DIFF
--- a/frontend/src/components/SidebarApp.module.scss
+++ b/frontend/src/components/SidebarApp.module.scss
@@ -1,7 +1,7 @@
 .imageWrapper {
   background-color: #e3e7eb;
   height: 215px;
-  width: fit-content;
+  width: 353px;
   overflow: hidden;
   display: flex;
   position: relative;


### PR DESCRIPTION
Before this commit, when no image was selected, the placeholder wouldn't
span the width of the container. After this commit, with or without an
image in the container, the placeholder background spans the width of
the container.

## Screenshots

![sidebar-before.jpg](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/676b927f-6ad0-48ae-acd1-31db42f76827/sidebar-before.jpg)

![sidebar-after.jpg](https://graphite-user-uploaded-assets.s3.amazonaws.com/vkhjmXjzdqOiU0HS7RdK/4dba61e6-4d28-404f-ac7a-60ec8187e492/sidebar-after.jpg)