### PR TITLE
fix(pd): sizes never set to null or undefined

### DIFF
--- a/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
+++ b/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
@@ -88,6 +88,16 @@ module.exports.render = function (context, modelIn) {
     );
     if (!fixedSize) {
       model.image_sizes = content.sizes;
+    } else if (fixedSize) {
+      // If fixed size image but we're not given the content width, have sizes
+      // fallback to browser default.
+      if (!content.width) {
+        model.image_sizes = "100vw";
+        // If we know the image width but sizes is not provided, use the width
+        // as the sizes value.
+      } else {
+        model.image_sizes = content.width + "px";
+      }
     }
   }
 


### PR DESCRIPTION
Before this commit, sizes would be `undefined` if the user left the
`sizes` field emtpy in the page designer attribute editor.

After this commit, `sizes` is set either to the image's `width`
attribute if provided or `100vw`, the browser default, if not provided.