### PR TITLE
fix: ensure sizes is never set to null/undefined

### DIFF
--- a/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
+++ b/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
@@ -53,7 +53,8 @@ module.exports.render = function (context, modelIn) {
     content.fit != null && { fit: content.fit }
   );
 
-  const fixedSize = content.width != null;
+  // content.width is guaranteed to be a number or undefined by SF
+  const fixedSize = content.width != null && content.width > 0;
 
   const ixlib = "sfccPD-" + version.version;
 
@@ -84,7 +85,7 @@ module.exports.render = function (context, modelIn) {
         libraryParam: ixlib,
       }
     );
-    if (!fixedSize) {
+    if (!fixedSize && content.sizes != null && content.sizes != "") {
       model.image_sizes = content.sizes;
     }
   }

--- a/cartridges/int_imgix_pd/cartridge/templates/default/experience/components/imgix/imageComponent.isml
+++ b/cartridges/int_imgix_pd/cartridge/templates/default/experience/components/imgix/imageComponent.isml
@@ -8,7 +8,7 @@
           alt="${pdict.alt ? pdict.alt : noText}" />
       </a>
       <iselse>
-        <img src="${pdict.image_src}" srcset="${pdict.image_srcset}" sizes="${pdict.image_sizes}"
+        <img src="${pdict.image_src}" srcset="${pdict.image_srcset}" sizes="${pdict.image_sizes || ''}"
           alt="${pdict.alt ? pdict.alt : noText}" />
     </isif>
 <iselse/>

--- a/cartridges/int_imgix_pd/cartridge/templates/default/experience/components/imgix/imageComponent.isml
+++ b/cartridges/int_imgix_pd/cartridge/templates/default/experience/components/imgix/imageComponent.isml
@@ -4,7 +4,7 @@
     <isprint value="${pdict.title}" />
     <isif condition="${!empty(pdict.anchorTagUrl)}">
       <a href="${pdict.anchorTagUrl}" aria-label="${pdict.alt ? pdict.alt : 'no alt text'}">
-        <img src="${pdict.image_src}" srcset="${pdict.image_srcset}" sizes="${pdict.image_sizes}"
+        <img src="${pdict.image_src}" srcset="${pdict.image_srcset}" sizes="${pdict.image_sizes || ''}"
           alt="${pdict.alt ? pdict.alt : noText}" />
       </a>
       <iselse>


### PR DESCRIPTION
Before this PR, in the Page Designer, the img tag's `sizes` attribute could be set to `undefined` or `null` depending on the situation. After this PR, two precautions were taken to ensure this can't happen.

1. The `model.image_sizes` data that is passed to the ISML template is only set if `content.sizes` actually has a useful value (i.e. not null-y and not an empty string)
2. In the ISML template, if no value is passed, before this would set `sizes` to `null`. Now, sizes is set to an empty string, which instructs browsers to fallback to the default value (`100vw`). I chose not to set `100vw` as the default since this allows browsers to behave smarter as they are more developed.
