### PR TITLE
fix(pd): set ixlib correctly for srcset

### DIFF
--- a/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
+++ b/cartridges/int_imgix_pd/cartridge/experience/components/imgix/imageComponent.js
@@ -78,13 +78,11 @@ module.exports.render = function (context, modelIn) {
     model.image_srcset = ImgixClient._buildSrcSet(
       rawImageUrl,
       Object.assign({}, defaultParamsJSON, customImgixParams),
-      Object.assign(
-        {
-          includeLibraryParam: false,
-          libraryParam: ixlib,
-        },
-        mediaWidth && { maxWidth: mediaWidth }
-      )
+      Object.assign({}, mediaWidth && { maxWidth: mediaWidth }),
+      {
+        includeLibraryParam: false,
+        libraryParam: ixlib,
+      }
     );
     if (!fixedSize) {
       model.image_sizes = content.sizes;


### PR DESCRIPTION
Before this PR, the `srcset` had an incorrect ixlib. Now, the srcset is set correctly.

<img width="809" alt="image" src="https://user-images.githubusercontent.com/615334/155547594-648bd5e8-6e9f-4314-bdbf-ff293dc73749.png">
