### PR TITLE
fix: locking logic should only factor in product locked state

### DIFF
--- a/frontend/src/components/ExtensionApp.tsx
+++ b/frontend/src/components/ExtensionApp.tsx
@@ -156,7 +156,6 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
   };
 
   const images = productImages || [];
-  const disabled = images === undefined || images.length === 0 || locked;
   const selectedSourceId = selectedProductImageId.split("/")[0];
   const selectedProductImage = images.find(
     (image) => image.imgix_metadata?.id === selectedProductImageId
@@ -232,7 +231,7 @@ export function ExtensionApp({ onChange, apiKey, data }: ISidebarAppProps) {
         <ProductPageImages
           onClick={onProductImageClick}
           images={productImages}
-          disabled={disabled}
+          disabled={locked}
         />
       </div>
     </div>


### PR DESCRIPTION
We no longer need to ensure that the JSON field is not empty or the array is empty before rendering <PreductPageImages> as that will no longer lead the app to crash (we've handled those issues elsewhere). Furthermore, the logic as it stood impeded products without imgix images to be edible.

This commit instead disables the component depending on whether or not
the lock icons are present alone.

## Before this PR
Extension would stay locked for products with no imgix images

## After this PR
Extension only locks if "Locked" icon is present.

# Video

https://user-images.githubusercontent.com/16711614/156667080-4065a2a4-99a3-41d5-a7c9-0da9bba26460.mov


