### PR TITLE
docs: make user guide link an absolute URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Salesforce Commerce Cloud integration between imgix's Image Manager product an
 
 ## Documentation
 
-Extensive documentation for this integration can be found in the [`documentation/imgix Commerce Cloud Integration Documentation.pdf`](documentation/imgix%20Commerce%20Cloud%20Integration%20Documentation.pdf) file.
+Extensive documentation for this integration can be found in the [`documentation/imgix Commerce Cloud Integration Documentation.pdf`](https://github.com/imgix/sf-commerce-cloud/blob/main/documentation/imgix%20Commerce%20Cloud%20Integration%20Documentation.pdf) file.
 
 ## License
 


### PR DESCRIPTION
imgix docs can't resolves GH relative URLs. We need to make this an absolute URL for the docs page to read the link correctly.
