### PR TITLE
feat: add srcset values to product model

### DIFF
--- a/src/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.ts
+++ b/src/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.ts
@@ -16,30 +16,6 @@ const IMGIX_CORE_DEFAULT_PARAMS = {
 const IMGIX_CORE_DEFAULT_OPTIONS = {
   includeLibraryParam: false,
 };
-// Store the imgixAttributes custom preference group values for the current site
-const imgixBaseURL: string =
-  currentSite.getCustomPreferenceValue("imgixBaseURL") || "";
-const imgixEnableProductImageProxy: boolean =
-  currentSite.getCustomPreferenceValue("imgixEnableProductImageProxy");
-const imgixDefaultParamsString: string =
-  currentSite.getCustomPreferenceValue("imgixProductDefaultParams") || "";
-
-// Create imgix params object from imgixDefaultParamsString custom preference
-const imgixDefaultParams = imgixDefaultParamsString
-  .split("&")
-  .reduce((p, paramString: string) => {
-    const equalsIndex = paramString.indexOf("=");
-    if (equalsIndex < 0) {
-      return p;
-    }
-    const key = paramString.substring(0, equalsIndex);
-    const value = paramString.substring(equalsIndex + 1);
-    p[key] = value;
-    return p;
-  }, {} as Record<string, string>);
-
-// Determine if baseURL string was provided
-const isBaseURLSet: boolean = imgixBaseURL.trim().length > 0;
 
 /**
  * @constructor
@@ -57,6 +33,31 @@ function Images(
   },
   imageConfig: { types: any[]; quantity: string }
 ) {
+  // Store the imgixAttributes custom preference group values for the current site
+  const imgixBaseURL: string =
+    currentSite.getCustomPreferenceValue("imgixBaseURL") || "";
+  const imgixEnableProductImageProxy: boolean =
+    currentSite.getCustomPreferenceValue("imgixEnableProductImageProxy");
+  const imgixDefaultParamsString: string =
+    currentSite.getCustomPreferenceValue("imgixProductDefaultParams") || "";
+
+  // Create imgix params object from imgixDefaultParamsString custom preference
+  const imgixDefaultParams = imgixDefaultParamsString
+    .split("&")
+    .reduce((p, paramString: string) => {
+      const equalsIndex = paramString.indexOf("=");
+      if (equalsIndex < 0) {
+        return p;
+      }
+      const key = paramString.substring(0, equalsIndex);
+      const value = paramString.substring(equalsIndex + 1);
+      p[key] = value;
+      return p;
+    }, {} as Record<string, string>);
+
+  // Determine if baseURL string was provided
+  const isBaseURLSet: boolean = imgixBaseURL.trim().length > 0;
+
   /**
    * Parse imgixData custom attribute JSON string into an object if it exists.
    * Depending on whether the product is an instance of ProductVariationModel or

--- a/src/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.ts
+++ b/src/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.ts
@@ -134,6 +134,12 @@ function Images(
           IMGIX_CORE_DEFAULT_OPTIONS
         );
 
+        const imageSrcSet = ImgixCore.buildSrcSet(rawURL, {
+          ...IMGIX_CORE_DEFAULT_PARAMS,
+          ...imgixDefaultParams,
+          ...sizeParams,
+        });
+
         return {
           alt: image.alt,
           url: imageURL,
@@ -141,6 +147,7 @@ function Images(
           title: image.title,
           absURL: imageURL,
           rawURL,
+          srcSet: imageSrcSet,
         };
       });
       this[viewType] = result;
@@ -170,6 +177,10 @@ function Images(
             IMGIX_CORE_DEFAULT_OPTIONS
           );
 
+          const imageSrcSet = ImgixCore.buildSrcSet(rawURL, {
+            ...imgixParams,
+          });
+
           result = [
             {
               alt: firstImage.alt,
@@ -178,6 +189,7 @@ function Images(
               index: "0",
               absURL: imageURL,
               rawURL,
+              srcSet: imageSrcSet,
             },
           ];
         }


### PR DESCRIPTION
This commit adds a `srcSet` value to the product image model. So that,
in an ISML template, you could set and image `srcset` value using
`pdict.image.srcSet` , or just `image.srcSet` depending on your template
setup.

## Before this commit
the product image model did not automatically generate a srcset for the image. 

## After this commit
the product image model has a `srcSet` attribute that can be used in ISML templates.

## screenshot
<img width="908" alt="Screen Shot 2022-03-24 at 3 56 00 PM" src="https://user-images.githubusercontent.com/16711614/160023385-ea1a2b05-05fd-4b7e-84fe-bcfbbe5b9e11.png">


## Testing these changes
In order to test these changes, you need to update the salesforce reference architecture component templates, [`ImageCarousel.isml`](https://github.com/SalesforceCommerceCloud/storefront-reference-architecture/blob/ea3484b32f641f24f22744c372afce030eaffb8c/cartridges/app_storefront_base/cartridge/templates/default/product/components/imageCarousel.isml) and [`productImageTile.isml`](https://github.com/SalesforceCommerceCloud/storefront-reference-architecture/blob/2d131c415d08b2f2de8e479ead63bb9ef698697d/cartridges/app_storefront_base/cartridge/templates/default/product/components/productTileImage.isml) templates (at least), so that they reference the `image.srcSet` attribute in the `img` tag.

You also should set the `sizes` attribute in those templates. In most cases this _will_ be necessary, otherwise, due to the layout of the page/the CSS not being explicit about the container size, the browser will select an image that's too large from the `srcset`.

```isml
<img 
  class="tile-image" 
  src="${product.images.medium[0].url}" 
  alt="${product.productName}"
  title="${product.images.medium[0].title}" 
  srcset="${product.images.medium[0].srcSet}"
  sizes="(min-width: 400px) 400px, (min-width: 800px) 800px, 100vw"
/>
```