### PR TITLE
chore: add tracking header to imgix API requests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
-    "imgix-management-js": "^1.2.1",
+    "imgix-management-js": "^1.3.0",
     "node-sass": "^6.0.1",
     "react": "^17.0.2",
     "react-app-rewired": "^2.1.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-commerce-cloud-fe",
-  "version": "0.1.0",
+  "version": "22.2.0",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.11.4",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,12 +1,16 @@
 import { createBreakoutApp } from "./index-breakout";
-import { createSidebarApp } from "./index-sidebar";
 import { runExtension } from "./index-extension";
+import { createSidebarApp } from "./index-sidebar";
+import { setAPIEnvironment } from "./services/imgixAPIService";
 
 if (process.env.REACT_APP_APP_TYPE === "sidebar") {
+  setAPIEnvironment("page_designer");
   createSidebarApp();
 } else if (process.env.REACT_APP_APP_TYPE === "breakout") {
+  setAPIEnvironment("page_designer");
   createBreakoutApp();
 } else if (process.env.REACT_APP_APP_TYPE === "extension") {
+  setAPIEnvironment("products");
   runExtension();
 } else {
   throw new Error("REACT_APP_APP_TYPE is not set");

--- a/frontend/src/services/imgixAPIService.ts
+++ b/frontend/src/services/imgixAPIService.ts
@@ -1,4 +1,5 @@
 import ImgixManagementJS from "imgix-management-js";
+import PACKAGE_VERSION from "../../package.json";
 import {
   ImgixGETAssetsData,
   ImgixGETSourcesData,
@@ -23,6 +24,7 @@ const makeRequest = async <TData = {}>({
 }) => {
   const client = new ImgixManagementJS({
     apiKey: apiKey,
+    pluginOrigin: `sfcc/v${PACKAGE_VERSION.version}`,
   });
   const response = await client.request(url, {
     method,

--- a/frontend/src/services/imgixAPIService.ts
+++ b/frontend/src/services/imgixAPIService.ts
@@ -1,9 +1,25 @@
 import ImgixManagementJS from "imgix-management-js";
-import PACKAGE_VERSION from "../../package.json";
+import PACKAGE from "../../package.json";
 import {
   ImgixGETAssetsData,
   ImgixGETSourcesData,
 } from "../types/imgixAPITypes";
+
+export type IAPIEnvironment = "page_designer" | "products";
+let environment: IAPIEnvironment | undefined = undefined;
+
+export const setAPIEnvironment = (_environment: IAPIEnvironment) =>
+  (environment = _environment);
+
+const getPluginOriginValue = (): string => {
+  if (environment === "page_designer") {
+    return "sfcc-page_designer/v" + PACKAGE.version;
+  }
+  if (environment === "products") {
+    return "sfcc-products/v" + PACKAGE.version;
+  }
+  return "sfcc/v" + PACKAGE.version;
+};
 
 /**
  * Make a request to the imgix API.
@@ -24,7 +40,7 @@ const makeRequest = async <TData = {}>({
 }) => {
   const client = new ImgixManagementJS({
     apiKey: apiKey,
-    pluginOrigin: `sfcc/v${PACKAGE_VERSION.version}`,
+    pluginOrigin: getPluginOriginValue(),
   });
   const response = await client.request(url, {
     method,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8099,10 +8099,10 @@ ignore@^5.1.4, ignore@^5.1.8:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-imgix-management-js@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/imgix-management-js/-/imgix-management-js-1.2.1.tgz#0422420f87eeab7e256edd6026e3fc4b71e4fbb9"
-  integrity sha512-OvYn9CxBHKhbxs1O4n5vAivTHGjbWIbqyn4nz51AyLP7/Es2hnjmX7Dcz1XBl9YIDS8Qov+h7OA61JCtQuK/Kg==
+imgix-management-js@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/imgix-management-js/-/imgix-management-js-1.3.0.tgz#d0d51152d73ffbda7d605d6ccbec2d3c3434b9b1"
+  integrity sha512-YvCNjwn/wN2WHH2V7SkZFf00HgTNNfvIyljOYbaSY+zxeq7thuzGW2bFhVvmPEySDiCZt26qJFmdZHJNnKpVRQ==
   dependencies:
     node-fetch "^2.6.0"
 


### PR DESCRIPTION
This PR adds the `x-imgix-plugin` header to requests made to the imgix management API, made possible by the imgix-management-js library.

Outstanding questions:
- what should the `x-imgix-plugin` be set to? At the moment, it's set to `sfcc/v<VERSION>`
- should we have different `x-imgix-plugin` values for different sections of the plugin?

🛑 This is currently blocked by the imgix API not allowing the `x-imgix-plugin` header in the CORS OPTIONS request, but with CORS turned off the request worked.

<img width="644" alt="image" src="https://user-images.githubusercontent.com/615334/161929989-58403883-a3d6-4b20-a51d-75b56e5d3b9a.png">

