### PR TITLE
fix: include demandware in extension glob

### DIFF
--- a/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.js
+++ b/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.js
@@ -37,7 +37,7 @@ var ProductVariationModel = require("dw/catalog/ProductVariationModel");
 var Variant = require("dw/catalog/Variant");
 var Product = require("dw/catalog/Product");
 var IMGIX_CORE_DEFAULT_PARAMS = {
-    ixlib: "sf-22.2.0",
+    ixlib: "sf-22.2.1",
 };
 var IMGIX_CORE_DEFAULT_OPTIONS = {
     includeLibraryParam: false,

--- a/src/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.ts
+++ b/src/cartridges/int_imgix_products_sfra/cartridge/models/product/productImages.ts
@@ -11,7 +11,7 @@ const Variant = require("dw/catalog/Variant");
 const Product = require("dw/catalog/Product");
 
 const IMGIX_CORE_DEFAULT_PARAMS = {
-  ixlib: "sf-22.2.0",
+  ixlib: "sf-22.2.1",
 };
 const IMGIX_CORE_DEFAULT_OPTIONS = {
   includeLibraryParam: false,

--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -12,11 +12,17 @@
   "permissions": ["storage"],
   "content_scripts": [
     {
-      "matches": ["https://*.salesforce.com/*ViewProduct_52*"],
+      "matches": [
+        "https://*.salesforce.com/*ViewProduct_52*",
+        "https://*.demandware.net/*ViewProduct_52*"
+      ],
       "css": ["src/inject/inject.css"]
     },
     {
-      "matches": ["https://*.salesforce.com/*ViewProduct_52*"],
+      "matches": [
+        "https://*.salesforce.com/*ViewProduct_52*",
+        "https://*.demandware.net/*ViewProduct_52*"
+      ],
       "js": ["src/inject/inject.js"]
     }
   ],


### PR DESCRIPTION
## Before this PR:

- only domains with the `salesforce.com` [glob](https://developer.chrome.com/docs/extensions/mv3/content_scripts/#matchAndGlob) pattern would load the extension.
- management-js ixlib version did not match extension version

## After this PR

- domains with the `demandware.com` [glob](https://developer.chrome.com/docs/extensions/mv3/content_scripts/#matchAndGlob) pattern will also load the extension.
- management js version matches extension version

## Steps to test
1. clone branch this locally
2. install unpacked extension in chrome
3. enter the API key in extensions settings
4. try to us in a `*.demandware.com/*ViewProduct_52*` domain